### PR TITLE
Improve chat shutdown sequence and websocket cleanup

### DIFF
--- a/cmd/example_chat/view.go
+++ b/cmd/example_chat/view.go
@@ -100,7 +100,7 @@ func handleWS(w http.ResponseWriter, r *http.Request, h *hub) {
 			if leftUser != "" {
 				h.broadcast(message{TS: time.Now().UTC(), User: leftUser, Event: "left"})
 			}
-			conn.Close(websocket.StatusNormalClosure, "")
+			_ = conn.Close(websocket.StatusNormalClosure, "")
 			cancelConn()
 			h.wg.Done()
 		}()

--- a/relaydns/utils.go
+++ b/relaydns/utils.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/libp2p/go-libp2p/core/host"
+	"github.com/rs/zerolog/log"
 )
 
 func AddrToTarget(listen string) string {
@@ -73,7 +74,11 @@ func fetchMultiaddrsFromHosts(base string, timeout time.Duration) ([]string, err
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			log.Debug().Err(err).Msg("response body close")
+		}
+	}()
 
 	var payload Hosts
 	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {


### PR DESCRIPTION
Refactors the shutdown logic in main.go to ensure proper order: cancels context, closes client, gracefully shuts down HTTP server, and waits for all websocket handler goroutines to finish. Adds a sync.WaitGroup to the hub in view.go to track active websocket handlers and ensures clean shutdown by waiting for all handlers to exit.