### PR TITLE
feat: add WASM client web server and improve service worker

### DIFF
--- a/cmd/webclient/index.html
+++ b/cmd/webclient/index.html
@@ -28,7 +28,7 @@
                 setTimeout(() => {
                     showStatus('Reloading page...', 'loading');
                     location.reload();
-                }, 500);
+                }, 1000);
             } catch (error) {
                 showStatus('Service Worker registration failed: ' + error.message, 'error');
             }


### PR DESCRIPTION
- Implement serverWorker in main_js.go to start an HTTP server within the WASM client, serving a basic HTML page with server ID
- Update service-worker.js to handle fetch events asynchronously, ensure WASM initialization, and provide better error responses
- Increase page reload timeout in index.html from 500ms to 1000ms for improved stability after service worker registration

This enables the web client to act as a server in the WASM environment, enhancing functionality for proxy and serving capabilities.