### PR TITLE
rEfAcToR: rename LookUpName to LookupName for correct capitalization

### DIFF
--- a/cmd/webclient/main_js.go
+++ b/cmd/webclient/main_js.go
@@ -36,7 +36,7 @@ var rdDialer = func(ctx context.Context, network, address string) (net.Conn, err
 	address = strings.TrimSuffix(address, ":80")
 	address = strings.TrimSuffix(address, ":443")
 
-	lease, err := rdClient.LookUpName(address)
+	lease, err := rdClient.LookupName(address)
 	if err == nil && lease != nil {
 		address = lease.Identity.Id
 		log.Debug().Str("name", address).Str("id", lease.Identity.Id).Msg("[SDK] Found lease")

--- a/sdk/sdk.go
+++ b/sdk/sdk.go
@@ -784,7 +784,7 @@ func (g *RDClient) GetRelays() []string {
 	return relays
 }
 
-func (g *RDClient) LookUpName(name string) (*rdverb.Lease, error) {
+func (g *RDClient) LookupName(name string) (*rdverb.Lease, error) {
 	log.Debug().Str("name", name).Msg("[SDK] Looking up name")
 	var relays []*rdRelay
 


### PR DESCRIPTION
Renamed the method `LookUpName` to `LookupName` in the SDK (`sdk.go`) and updated its call in the webclient (`main_js.go`) to fix the capitalization, removing the extra capital 'U' in "LookUp" to match standard spelling conventions. This improves code consistency and readability without altering functionality.