### PR TITLE
chore: update commented wasm_exec URL to reflect Go 1.25.3 lib path

### DIFF
--- a/cmd/webclient/service-worker.js
+++ b/cmd/webclient/service-worker.js
@@ -1,4 +1,4 @@
-// const wasm_exec_URL = "https://cdn.jsdelivr.net/gh/golang/go@go1.25.3/misc/wasm/wasm_exec.js";
+// const wasm_exec_URL = "https://cdn.jsdelivr.net/gh/golang/go@go1.25.3/lib/wasm/wasm_exec.js";
 const wasm_exec_URL = "/wasm_exec.js";
 const manifest_URL = "/manifest.json";
 


### PR DESCRIPTION
The commented URL in service-worker.js was pointing to the old misc/wasm directory, which has been moved to lib/wasm in Go's repository for version 1.25.3. This update ensures the comment accurately reflects the current location.