### PR TITLE
feat(docker): add image specification to portal service in docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,6 @@
 services:
   portal:
+    image: ghcr.io/gosuda/portal:1
     build:
       context: .
       dockerfile: Dockerfile


### PR DESCRIPTION
Specify a pre-built image from GitHub Container Registry to enable faster deployments and avoid rebuilding from Dockerfile on every run.