### PR TITLE
fix(relay-server): make portal link protocol-relative in view.go

### DIFF
--- a/cmd/relay-server/view.go
+++ b/cmd/relay-server/view.go
@@ -235,7 +235,7 @@ func convertLeaseEntriesToRows(serv *portal.RelayServer) []leaseRow {
 			dnsLabel = dnsLabel[:8] + "..."
 		}
 
-		link := fmt.Sprintf("https://%s.%s/", lease.Name, portalDomain)
+		link := fmt.Sprintf("//%s.%s/", lease.Name, portalDomain)
 
 		row := leaseRow{
 			Peer:        identityID,


### PR DESCRIPTION
Remove "https:" prefix from the link generation in convertLeaseEntriesToRows function to create a protocol-relative URL, allowing it to inherit the protocol (http or https) from the current page for better flexibility and security.