### PR TITLE
feat(cmd/relay-server): enhance lease link generation to support custom domain

### DIFF
--- a/cmd/relay-server/view.go
+++ b/cmd/relay-server/view.go
@@ -271,7 +271,19 @@ func convertLeaseEntriesToRows(serv *portal.RelayServer) []leaseRow {
 			dnsLabel = dnsLabel[:8] + "..."
 		}
 
-		link := fmt.Sprintf("//%s.%s/", lease.Name, portalHost)
+		// Use frontend pattern if available, otherwise fall back to portalHost
+		var link string
+		if portalFrontendPattern != "" {
+			// For wildcard patterns like *.localhost:4017, replace * with lease name
+			if strings.HasPrefix(portalFrontendPattern, "*.") {
+				link = fmt.Sprintf("//%s%s", lease.Name, strings.TrimPrefix(portalFrontendPattern, "*"))
+			} else {
+				// For non-wildcard patterns, construct URL with lease name as subdomain
+				link = fmt.Sprintf("//%s.%s/", lease.Name, portalFrontendPattern)
+			}
+		} else {
+			link = fmt.Sprintf("//%s.%s/", lease.Name, portalHost)
+		}
 
 		row := leaseRow{
 			Peer:        identityID,


### PR DESCRIPTION
Update convertLeaseEntriesToRows to use portalFrontendPattern for link URLs, falling back to portalHost. Supports wildcard patterns (*.domain) by replacing '*' with lease name, enabling flexible subdomain handling.

Handle cases like `*.portal.app` with `portal.com`