### PR TITLE
perf: Add TCP_NODELAY utilities and apply them to networking

### DIFF
--- a/cmd/relay-server/bps_manager.go
+++ b/cmd/relay-server/bps_manager.go
@@ -12,7 +12,7 @@ import (
 // BPSManager manages per-lease bytes-per-second rate limiting
 type BPSManager struct {
 	mu         sync.Mutex
-	bpsLimits  map[string]int64            // leaseID -> bytes-per-second (0 = unlimited)
+	bpsLimits  map[string]int64             // leaseID -> bytes-per-second (0 = unlimited)
 	bpsBuckets map[string]*ratelimit.Bucket // leaseID -> rate limit bucket
 	defaultBPS int64                        // default bytes-per-second for new leases
 }

--- a/portal/integration_test.go
+++ b/portal/integration_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"gosuda.org/portal/portal/core/cryptoops"
 	"gosuda.org/portal/portal/core/proto/rdverb"
+	"gosuda.org/portal/utils"
 )
 
 // generateTestCredential creates a new credential for testing
@@ -26,9 +27,10 @@ func TestIntegration_FullFlow(t *testing.T) {
 	server.Start()
 	defer server.Stop()
 
-	// Create a listener for the server
-	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	// Create a listener for the server with TCP_NODELAY enabled
+	rawListener, err := net.Listen("tcp", "127.0.0.1:0")
 	require.NoError(t, err)
+	listener := utils.NewTCPNoDelayListener(rawListener)
 	defer listener.Close()
 
 	go func() {
@@ -47,6 +49,7 @@ func TestIntegration_FullFlow(t *testing.T) {
 	hostCred := generateTestCredential(t)
 	hostConn, err := net.Dial("tcp", serverAddr)
 	require.NoError(t, err)
+	require.NoError(t, utils.SetTCPNoDelay(hostConn))
 
 	hostClient := NewRelayClient(hostConn)
 	require.NotNil(t, hostClient)
@@ -75,6 +78,7 @@ func TestIntegration_FullFlow(t *testing.T) {
 	peerCred := generateTestCredential(t)
 	peerConn, err := net.Dial("tcp", serverAddr)
 	require.NoError(t, err)
+	require.NoError(t, utils.SetTCPNoDelay(peerConn))
 
 	peerClient := NewRelayClient(peerConn)
 	require.NotNil(t, peerClient)

--- a/sdk/sdk.go
+++ b/sdk/sdk.go
@@ -302,7 +302,7 @@ func (g *Client) listenerWorker(server *connRelay) {
 
 			if !exists {
 				log.Warn().Str("lease_id", lease).Msg("[SDK] No listener found for lease, closing connection")
-				incoming.SecureConnection.Close() // Close unused connection
+				incoming.Close() // Close unused connection
 				continue
 			}
 

--- a/sdk/sdk_e2e_test.go
+++ b/sdk/sdk_e2e_test.go
@@ -59,14 +59,18 @@ func TestE2E_ClientToAppThroughRelay(t *testing.T) {
 		}
 	})
 
+	// Create TCP listener with TCP_NODELAY enabled for low-latency relay protocol
+	relayListener, err := net.Listen("tcp", relayAddr)
+	require.NoError(t, err, "Failed to create relay listener")
+	noDelayListener := utils.NewTCPNoDelayListener(relayListener)
+
 	relayHTTPServer := &http.Server{
-		Addr:    relayAddr,
 		Handler: relayMux,
 	}
 
 	go func() {
 		log.Info().Str("addr", relayAddr).Msg("[TEST] Relay HTTP server starting")
-		if err := relayHTTPServer.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+		if err := relayHTTPServer.Serve(noDelayListener); err != nil && err != http.ErrServerClosed {
 			log.Error().Err(err).Msg("[TEST] Relay HTTP server error")
 		}
 	}()
@@ -219,12 +223,16 @@ func TestE2E_MultipleConnections(t *testing.T) {
 		relayServer.HandleConnection(stream)
 	})
 
+	// Create TCP listener with TCP_NODELAY enabled
+	relayListener, err := net.Listen("tcp", relayAddr)
+	require.NoError(t, err, "Failed to create relay listener")
+	noDelayListener := utils.NewTCPNoDelayListener(relayListener)
+
 	relayHTTPServer := &http.Server{
-		Addr:    relayAddr,
 		Handler: relayMux,
 	}
 
-	go relayHTTPServer.ListenAndServe()
+	go relayHTTPServer.Serve(noDelayListener)
 	defer func() {
 		ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
 		defer cancel()
@@ -359,12 +367,16 @@ func TestE2E_ConnectionTimeout(t *testing.T) {
 		relayServer.HandleConnection(stream)
 	})
 
+	// Create TCP listener with TCP_NODELAY enabled
+	relayListener, err := net.Listen("tcp", relayAddr)
+	require.NoError(t, err, "Failed to create relay listener")
+	noDelayListener := utils.NewTCPNoDelayListener(relayListener)
+
 	relayHTTPServer := &http.Server{
-		Addr:    relayAddr,
 		Handler: relayMux,
 	}
 
-	go relayHTTPServer.ListenAndServe()
+	go relayHTTPServer.Serve(noDelayListener)
 	defer func() {
 		ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
 		defer cancel()

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -5,21 +5,70 @@ import (
 	"fmt"
 	"io"
 	"mime"
+	"net"
 	"net/http"
 	"net/url"
 	"regexp"
 	"strings"
 
 	"github.com/gorilla/websocket"
+	"github.com/rs/zerolog/log"
 
 	"gosuda.org/portal/portal/utils/wsstream"
 )
 
+// SetTCPNoDelay enables TCP_NODELAY on a TCP connection to disable Nagle's algorithm.
+// Returns nil for non-TCP connections (e.g., Unix sockets, WebSocket over WASM).
+func SetTCPNoDelay(conn net.Conn) error {
+	if tcpConn, ok := conn.(*net.TCPConn); ok {
+		return tcpConn.SetNoDelay(true)
+	}
+	return nil
+}
+
+// TCPNoDelayListener wraps a net.Listener to enable TCP_NODELAY on accepted connections.
+type TCPNoDelayListener struct {
+	net.Listener
+}
+
+// Accept accepts a connection and enables TCP_NODELAY.
+func (l *TCPNoDelayListener) Accept() (net.Conn, error) {
+	conn, err := l.Listener.Accept()
+	if err != nil {
+		return nil, err
+	}
+	if err := SetTCPNoDelay(conn); err != nil {
+		log.Debug().Err(err).Msg("failed to set TCP_NODELAY on accepted connection")
+	}
+	return conn, nil
+}
+
+// NewTCPNoDelayListener wraps a listener to enable TCP_NODELAY on accepted connections.
+func NewTCPNoDelayListener(l net.Listener) *TCPNoDelayListener {
+	return &TCPNoDelayListener{Listener: l}
+}
+
 // NewWebSocketDialer returns a dialer that establishes WebSocket connections
-// and wraps them as io.ReadWriteCloser.
+// and wraps them as io.ReadWriteCloser. TCP_NODELAY is enabled on the underlying
+// TCP connection to minimize latency for interactive relay protocols.
 func NewWebSocketDialer() func(context.Context, string) (io.ReadWriteCloser, error) {
+	dialer := &websocket.Dialer{
+		NetDialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
+			d := &net.Dialer{}
+			conn, err := d.DialContext(ctx, network, addr)
+			if err != nil {
+				return nil, err
+			}
+			if err := SetTCPNoDelay(conn); err != nil {
+				log.Debug().Err(err).Msg("failed to set TCP_NODELAY on WebSocket connection")
+			}
+			return conn, nil
+		},
+		HandshakeTimeout: websocket.DefaultDialer.HandshakeTimeout,
+	}
+
 	return func(ctx context.Context, url string) (io.ReadWriteCloser, error) {
-		wsConn, _, err := websocket.DefaultDialer.Dial(url, nil)
+		wsConn, _, err := dialer.DialContext(ctx, url, nil)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
This pull request introduces a consistent approach to enabling TCP_NODELAY (disabling Nagle's algorithm) across the entire relay protocol stack, including server, SDK, and test components. This change aims to reduce network latency for interactive relay connections by ensuring TCP_NODELAY is set on all TCP listeners and connections. The update also adds utility functions and thorough unit tests for this functionality.

**TCP_NODELAY integration across relay protocol:**

* Added `SetTCPNoDelay`, `TCPNoDelayListener`, and `NewTCPNoDelayListener` utility functions to `utils/utils.go`, allowing TCP_NODELAY to be enabled on any TCP connection or listener. Also updated the WebSocket dialer to set TCP_NODELAY for underlying TCP connections.
* Updated all relay server and test listeners (in `cmd/relay-server/view.go`, `sdk/sdk_e2e_test.go`, `portal/core/cryptoops/handshaker_test.go`, and `portal/integration_test.go`) to use `NewTCPNoDelayListener` for low-latency operation. All client-side test connections now explicitly set TCP_NODELAY using `SetTCPNoDelay`. [[1]](diffhunk://#diff-a2863198688f851eaed1dc07db9ad6da857444c6527c4dbe013a25ea1a54dc9fL179-R191) [[2]](diffhunk://#diff-f22711b7674e8043720a07446b60a82adb8861af203a592d05c49ebb31742f62R62-R73) [[3]](diffhunk://#diff-f22711b7674e8043720a07446b60a82adb8861af203a592d05c49ebb31742f62R226-R235) [[4]](diffhunk://#diff-f22711b7674e8043720a07446b60a82adb8861af203a592d05c49ebb31742f62R370-R379) [[5]](diffhunk://#diff-cc04276416dc612625d1c66bf1e4037903d35f04e6f03d8a3a4ddecf838b62f7R14-R24) [[6]](diffhunk://#diff-cc04276416dc612625d1c66bf1e4037903d35f04e6f03d8a3a4ddecf838b62f7L685-R696) [[7]](diffhunk://#diff-cc04276416dc612625d1c66bf1e4037903d35f04e6f03d8a3a4ddecf838b62f7L710-R724) [[8]](diffhunk://#diff-79909e74a8c8ce4ed8927d31e9efaebb92bbb45ab6fada9d7aa93cb85d32f618L29-R33) [[9]](diffhunk://#diff-79909e74a8c8ce4ed8927d31e9efaebb92bbb45ab6fada9d7aa93cb85d32f618R52) [[10]](diffhunk://#diff-79909e74a8c8ce4ed8927d31e9efaebb92bbb45ab6fada9d7aa93cb85d32f618R81)

**Testing and validation:**

* Added comprehensive unit tests for `SetTCPNoDelay` and `TCPNoDelayListener` in `utils/utils_test.go`, including tests for TCP and non-TCP connections, listener wrapping, and address propagation.

**Minor fixes and cleanup:**

* Simplified lease row filtering in `convertLeaseEntriesToRows` by using a more idiomatic boolean check.
* Fixed SDK connection cleanup to use the correct connection object (`incoming.Close()` instead of `incoming.SecureConnection.Close()`).

---

Resolves #77