### PR TITLE
Refactor/portal tunnel

### DIFF
--- a/cmd/portal-tunnel/config.go
+++ b/cmd/portal-tunnel/config.go
@@ -11,7 +11,6 @@ import (
 
 var defaultProtocols = []string{"http/1.1", "h2"}
 
-// AppConfig describes a local app tunneled through Portal.
 type AppConfig struct {
 	Name      string       `yaml:"name"`
 	Target    string       `yaml:"target"`
@@ -19,13 +18,11 @@ type AppConfig struct {
 	Metadata  sdk.Metadata `yaml:"metadata,omitempty"`
 }
 
-// TunnelConfig represents the YAML configuration schema for portal-tunnel.
 type TunnelConfig struct {
 	Relays []string  `yaml:"relays"`
 	App    AppConfig `yaml:"app"`
 }
 
-// LoadConfig reads the YAML file at path, parses it into TunnelConfig, and validates it for single-app use.
 func LoadConfig(path string) (*TunnelConfig, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {


### PR DESCRIPTION
Refactor without changing behavior

copilot summary : 
This pull request refactors the terminology and code structure in the tunnel service from "service" to "app" for clarity and consistency, and reorganizes the main logic to improve maintainability. The most important changes are grouped below.

**Terminology and Data Structure Updates**

* Renamed `ServiceConfig` to `AppConfig` and updated all related struct fields, variable names, and YAML schema references from `service` to `app` in `config.go` and throughout the codebase. [[1]](diffhunk://#diff-fc46d4b564d92fe74440feb351a8d17c61572f1ecc83cd3eeffcdd2ab6f82996L14-L28) [[2]](diffhunk://#diff-fc46d4b564d92fe74440feb351a8d17c61572f1ecc83cd3eeffcdd2ab6f82996L39-R37) [[3]](diffhunk://#diff-fc46d4b564d92fe74440feb351a8d17c61572f1ecc83cd3eeffcdd2ab6f82996L62-R70)
* Updated CLI flag descriptions and environment variable references to use "app" instead of "service" in `main.go`.

**Refactoring and Code Organization**

* Introduced a new `Tunnel` struct to encapsulate relay URLs, app configuration, and origin, and refactored configuration loading and flag parsing logic into methods on `Tunnel`. [[1]](diffhunk://#diff-2868495911e6cc798af70512769c079e5fb4acd09dfe78260a10954fdc2952fdL27-R65) [[2]](diffhunk://#diff-2868495911e6cc798af70512769c079e5fb4acd09dfe78260a10954fdc2952fdL143-R170)
* Moved the main tunnel run logic into a new `Tunnel.Run` method, replacing the previous procedural approach and improving separation of concerns. [[1]](diffhunk://#diff-2868495911e6cc798af70512769c079e5fb4acd09dfe78260a10954fdc2952fdL143-R170) [[2]](diffhunk://#diff-2868495911e6cc798af70512769c079e5fb4acd09dfe78260a10954fdc2952fdL280-R318)

**Logging and User Messaging**

* Updated all user-facing log messages to use "app" instead of "service" for improved clarity. [[1]](diffhunk://#diff-2868495911e6cc798af70512769c079e5fb4acd09dfe78260a10954fdc2952fdL143-R170) [[2]](diffhunk://#diff-2868495911e6cc798af70512769c079e5fb4acd09dfe78260a10954fdc2952fdL256-R185) [[3]](diffhunk://#diff-2868495911e6cc798af70512769c079e5fb4acd09dfe78260a10954fdc2952fdL280-R318)

**Connection Handling**

* Updated error messages in connection proxying to refer to "app" instead of "service" and moved connection proxy logic to the bottom of `main.go`. [[1]](diffhunk://#diff-2868495911e6cc798af70512769c079e5fb4acd09dfe78260a10954fdc2952fdL143-R170) [[2]](diffhunk://#diff-2868495911e6cc798af70512769c079e5fb4acd09dfe78260a10954fdc2952fdL280-R318)

**Relay URL Normalization**

* Replaced the standalone `normalizeRelayURLs` function with methods on the `Tunnel` struct for relay URL parsing and de-duplication. [[1]](diffhunk://#diff-2868495911e6cc798af70512769c079e5fb4acd09dfe78260a10954fdc2952fdL143-R170) [[2]](diffhunk://#diff-2868495911e6cc798af70512769c079e5fb4acd09dfe78260a10954fdc2952fdL280-R318)