### PR TITLE
feat: Add admin authentication system with secret key

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,7 @@ COPY --from=builder /src/bin/relay-server /usr/bin/relay-server
 ENV PORTAL_URL=http://localhost:4017
 ENV PORTAL_APP_URL=http://*.localhost:4017
 ENV BOOTSTRAP_URIS=ws://localhost:4017/relay
+ENV ADMIN_SECRET_KEY=
 ENV NOINDEX=false
 ENV TZ=UTC
 

--- a/README.md
+++ b/README.md
@@ -42,6 +42,10 @@ docker compose up
 # 2. Open in browser
 http://localhost:4017
 
+# 3. Access admin panel at http://localhost:4017/admin
+# If ADMIN_SECRET_KEY is not set, a random key will be auto-generated and shown in logs
+# To use your own key:
+ADMIN_SECRET_KEY=your-secret-key docker compose up
 ```
 
 For a public deployment guide (DNS, TLS, reverse proxy), see [docs/portal-deploy-guide.md](docs/portal-deploy-guide.md).

--- a/cmd/relay-server/frontend/package-lock.json
+++ b/cmd/relay-server/frontend/package-lock.json
@@ -14,6 +14,7 @@
         "@radix-ui/react-scroll-area": "^1.2.10",
         "@radix-ui/react-select": "^2.2.6",
         "@radix-ui/react-slot": "^1.2.4",
+        "@radix-ui/react-tooltip": "^1.2.8",
         "@ssgoi/react": "^2.5.5",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
@@ -1658,6 +1659,58 @@
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.4.tgz",
       "integrity": "sha512-Jl+bCv8HxKnlTLVrcDE8zTMJ09R9/ukw4qBs/oZClOfoQk/cOTbDn+NceXfV7j09YPVQUryJPHurafcSg6EVKA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tooltip": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-tooltip/-/react-tooltip-1.2.8.tgz",
+      "integrity": "sha512-tY7sVt1yL9ozIxvmbtN5qtmH2krXcBCfjEiCgKGLqunJHvgvZG2Pcl2oQ3kbcZARb1BGEHdkLzcYGO8ynVlieg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-dismissable-layer": "1.1.11",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-popper": "1.2.8",
+        "@radix-ui/react-portal": "1.1.9",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-slot": "1.2.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-visually-hidden": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tooltip/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-compose-refs": "1.1.2"

--- a/cmd/relay-server/frontend/package.json
+++ b/cmd/relay-server/frontend/package.json
@@ -18,6 +18,7 @@
     "@radix-ui/react-scroll-area": "^1.2.10",
     "@radix-ui/react-select": "^2.2.6",
     "@radix-ui/react-slot": "^1.2.4",
+    "@radix-ui/react-tooltip": "^1.2.8",
     "@ssgoi/react": "^2.5.5",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/cmd/relay-server/frontend/src/App.tsx
+++ b/cmd/relay-server/frontend/src/App.tsx
@@ -1,4 +1,5 @@
 import { Admin } from "@/pages/Admin";
+import { AdminLogin } from "@/pages/AdminLogin";
 import { ServerDetail } from "@/pages/ServerDetail";
 import { ServerList } from "@/pages/ServerList";
 import { Route, Routes } from "react-router-dom";
@@ -8,6 +9,7 @@ function App() {
     <Routes>
       <Route path="/" element={<ServerList />} />
       <Route path="/server/:id" element={<ServerDetail />} />
+      <Route path="/admin/login" element={<AdminLogin />} />
       <Route path="/admin" element={<Admin />} />
     </Routes>
   );

--- a/cmd/relay-server/frontend/src/components/Header.tsx
+++ b/cmd/relay-server/frontend/src/components/Header.tsx
@@ -1,15 +1,22 @@
 import { useEffect, useState } from "react";
-import { Moon, Sun } from "lucide-react";
+import { LogOut, Moon, Sun } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 import { TunnelCommandModal } from "@/components/TunnelCommandModal";
 import clsx from "clsx";
 
 interface HeaderProps {
   title?: string;
   isAdmin?: boolean;
+  onLogout?: () => void;
 }
 
-export function Header({ title = "PORTAL", isAdmin }: HeaderProps) {
+export function Header({ title = "PORTAL", isAdmin, onLogout }: HeaderProps) {
   const [theme, setTheme] = useState<"light" | "dark">("dark");
 
   useEffect(() => {
@@ -78,7 +85,7 @@ export function Header({ title = "PORTAL", isAdmin }: HeaderProps) {
         </a>
         <button
           onClick={toggleTheme}
-          className="text-foreground hover:text-primary transition-colors p-1 rounded-md hover:bg-secondary"
+          className="cursor-pointer text-foreground hover:text-primary transition-colors p-1 rounded-md hover:bg-secondary"
           aria-label="Toggle theme"
         >
           {theme === "dark" ? (
@@ -89,11 +96,33 @@ export function Header({ title = "PORTAL", isAdmin }: HeaderProps) {
         </button>
         <TunnelCommandModal
           trigger={
-            <Button className={clsx(isAdmin && "hidden sm:block")}>
+            <Button
+              className={clsx(isAdmin && "hidden sm:block", "cursor-pointer")}
+            >
               <span className="truncate">Add Your Server</span>
             </Button>
           }
         />
+        {isAdmin && onLogout && (
+          <TooltipProvider>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  variant="outline"
+                  size="icon"
+                  onClick={onLogout}
+                  className="cursor-pointer text-foreground hover:text-destructive"
+                  aria-label="Logout"
+                >
+                  <LogOut className="w-5 h-5" />
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent>
+                <p>Logout</p>
+              </TooltipContent>
+            </Tooltip>
+          </TooltipProvider>
+        )}
       </div>
     </header>
   );

--- a/cmd/relay-server/frontend/src/components/ServerCard.tsx
+++ b/cmd/relay-server/frontend/src/components/ServerCard.tsx
@@ -223,7 +223,7 @@ export function ServerCard({
         data-hero-key={`server-bg-${serverId}`}
         className={clsx(
           "relative bg-center bg-no-repeat bg-cover rounded-xl shadow-lg hover:shadow-xl transition-shadow duration-300 z-1 border border-foreground dark:border-foreground/40",
-          showAdminControls ? "h-[263.5px]" : "h-[174.5px]"
+          showAdminControls ? "h-[286px]" : "h-[174.5px]"
         )}
         style={{ ...(thumbnail && { backgroundImage: `url(${thumbnail})` }) }}
       >
@@ -452,10 +452,16 @@ export function ServerCard({
             />
           </div>
           <DialogFooter className="gap-2 sm:gap-0">
-            <Button variant="secondary" onClick={() => setShowBPSModal(false)}>
+            <Button
+              className="cursor-pointer"
+              variant="secondary"
+              onClick={() => setShowBPSModal(false)}
+            >
               Cancel
             </Button>
-            <Button onClick={handleBPSSave}>Save</Button>
+            <Button className="cursor-pointer" onClick={handleBPSSave}>
+              Save
+            </Button>
           </DialogFooter>
         </DialogContent>
       </Dialog>

--- a/cmd/relay-server/frontend/src/components/ServerListView.tsx
+++ b/cmd/relay-server/frontend/src/components/ServerListView.tsx
@@ -54,6 +54,8 @@ interface ServerListViewProps {
   onBulkApprove?: (leaseIds: string[]) => void;
   onBulkDeny?: (leaseIds: string[]) => void;
   onBulkBan?: (leaseIds: string[]) => void;
+  // Logout handler (admin only)
+  onLogout?: () => void;
 }
 
 function isAdminServer(
@@ -91,6 +93,8 @@ export function ServerListView({
   onBulkApprove,
   onBulkDeny,
   onBulkBan,
+  // Logout handler
+  onLogout,
 }: ServerListViewProps) {
   const [showFilterModal, setShowFilterModal] = useState(false);
   const [selectedLeaseIds, setSelectedLeaseIds] = useState<Set<string>>(
@@ -191,7 +195,7 @@ export function ServerListView({
         <div className="flex flex-1 justify-center">
           <div className="flex flex-col w-full max-w-6xl flex-1 px-0 md:px-8">
             <div className="sticky top-0 z-10 bg-background pb-4 pt-5">
-              <Header title={title} isAdmin={isAdmin} />
+              <Header title={title} isAdmin={isAdmin} onLogout={onLogout} />
               <div className="flex items-center gap-2">
                 <div className="flex-1">
                   <SearchBar

--- a/cmd/relay-server/frontend/src/components/TunnelCommandModal.tsx
+++ b/cmd/relay-server/frontend/src/components/TunnelCommandModal.tsx
@@ -88,7 +88,7 @@ export function TunnelCommandModal({ trigger }: TunnelCommandModalProps) {
     <Dialog>
       <DialogTrigger asChild>
         {trigger || (
-          <Button>
+          <Button className="cursor-pointer">
             <span className="truncate">Add Your Server</span>
           </Button>
         )}

--- a/cmd/relay-server/frontend/src/components/button/ApprovalModeToggle.tsx
+++ b/cmd/relay-server/frontend/src/components/button/ApprovalModeToggle.tsx
@@ -12,7 +12,7 @@ export const ApprovalModeToggle = ({
   <div className="flex rounded-lg overflow-hidden border border-foreground/20">
     <button
       onClick={() => onApprovalModeChange("auto")}
-      className={`px-4 h-10 text-sm font-medium transition-colors ${
+      className={`cursor-pointer px-4 h-10 text-sm font-medium transition-colors ${
         approvalMode === "auto"
           ? "bg-primary text-primary-foreground"
           : "bg-secondary text-secondary-foreground hover:bg-secondary/80"
@@ -22,7 +22,7 @@ export const ApprovalModeToggle = ({
     </button>
     <button
       onClick={() => onApprovalModeChange("manual")}
-      className={`px-4 h-10 text-sm font-medium transition-colors border-l border-foreground/20 ${
+      className={`cursor-pointer px-4 h-10 text-sm font-medium transition-colors border-l border-foreground/20 ${
         approvalMode === "manual"
           ? "bg-primary text-primary-foreground"
           : "bg-secondary text-secondary-foreground hover:bg-secondary/80"

--- a/cmd/relay-server/frontend/src/components/button/BanStatusButtons.tsx
+++ b/cmd/relay-server/frontend/src/components/button/BanStatusButtons.tsx
@@ -20,7 +20,7 @@ export const BanStatusButtons = ({
   >
     <button
       onClick={() => onBanFilterChange("all")}
-      className={`px-4 h-10 text-sm font-medium transition-colors ${
+      className={`cursor-pointer px-4 h-10 text-sm font-medium transition-colors ${
         banFilter === "all"
           ? "bg-primary text-primary-foreground"
           : "bg-secondary text-secondary-foreground hover:bg-secondary/80"
@@ -30,7 +30,7 @@ export const BanStatusButtons = ({
     </button>
     <button
       onClick={() => onBanFilterChange("active")}
-      className={`px-4 h-10 text-sm font-medium transition-colors border-l border-foreground/20 ${
+      className={`cursor-pointer px-4 h-10 text-sm font-medium transition-colors border-l border-foreground/20 ${
         banFilter === "active"
           ? "bg-green-600 text-white"
           : "bg-secondary text-secondary-foreground hover:bg-secondary/80"
@@ -40,7 +40,7 @@ export const BanStatusButtons = ({
     </button>
     <button
       onClick={() => onBanFilterChange("banned")}
-      className={`px-4 h-10 text-sm font-medium transition-colors border-l border-foreground/20 ${
+      className={`cursor-pointer px-4 h-10 text-sm font-medium transition-colors border-l border-foreground/20 ${
         banFilter === "banned"
           ? "bg-red-600 text-white"
           : "bg-secondary text-secondary-foreground hover:bg-secondary/80"

--- a/cmd/relay-server/frontend/src/components/ui/tooltip.tsx
+++ b/cmd/relay-server/frontend/src/components/ui/tooltip.tsx
@@ -1,0 +1,30 @@
+import * as React from "react"
+import * as TooltipPrimitive from "@radix-ui/react-tooltip"
+
+import { cn } from "@/lib/utils"
+
+const TooltipProvider = TooltipPrimitive.Provider
+
+const Tooltip = TooltipPrimitive.Root
+
+const TooltipTrigger = TooltipPrimitive.Trigger
+
+const TooltipContent = React.forwardRef<
+  React.ElementRef<typeof TooltipPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof TooltipPrimitive.Content>
+>(({ className, sideOffset = 4, ...props }, ref) => (
+  <TooltipPrimitive.Portal>
+    <TooltipPrimitive.Content
+      ref={ref}
+      sideOffset={sideOffset}
+      className={cn(
+        "z-50 overflow-hidden rounded-md bg-primary px-3 py-1.5 text-xs text-primary-foreground animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-[--radix-tooltip-content-transform-origin]",
+        className
+      )}
+      {...props}
+    />
+  </TooltipPrimitive.Portal>
+))
+TooltipContent.displayName = TooltipPrimitive.Content.displayName
+
+export { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider }

--- a/cmd/relay-server/frontend/src/hooks/useAuth.ts
+++ b/cmd/relay-server/frontend/src/hooks/useAuth.ts
@@ -1,0 +1,213 @@
+import { useCallback, useEffect, useState } from "react";
+
+const STORAGE_KEY = "admin_login_attempts";
+const MAX_ATTEMPTS = 3;
+const LOCK_DURATION_MS = 60 * 1000; // 1 minute
+
+interface LoginAttempts {
+  count: number;
+  lockedUntil: number | null;
+}
+
+interface AuthState {
+  isAuthenticated: boolean;
+  isLoading: boolean;
+  authEnabled: boolean;
+}
+
+interface LoginResult {
+  success: boolean;
+  error?: string;
+  locked?: boolean;
+  remaining_seconds?: number;
+}
+
+function getStoredAttempts(): LoginAttempts {
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    if (stored) {
+      return JSON.parse(stored);
+    }
+  } catch {
+    // Ignore parse errors
+  }
+  return { count: 0, lockedUntil: null };
+}
+
+function setStoredAttempts(attempts: LoginAttempts): void {
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(attempts));
+}
+
+function clearStoredAttempts(): void {
+  localStorage.removeItem(STORAGE_KEY);
+}
+
+export function useAuth() {
+  const [authState, setAuthState] = useState<AuthState>({
+    isAuthenticated: false,
+    isLoading: true,
+    authEnabled: true,
+  });
+
+  const [clientLock, setClientLock] = useState<{
+    isLocked: boolean;
+    remainingSeconds: number;
+  }>({
+    isLocked: false,
+    remainingSeconds: 0,
+  });
+
+  // Check client-side lock status
+  const checkClientLock = useCallback(() => {
+    const attempts = getStoredAttempts();
+    if (attempts.lockedUntil) {
+      const remaining = attempts.lockedUntil - Date.now();
+      if (remaining > 0) {
+        setClientLock({
+          isLocked: true,
+          remainingSeconds: Math.ceil(remaining / 1000),
+        });
+        return true;
+      } else {
+        // Lock expired, clear it
+        clearStoredAttempts();
+        setClientLock({ isLocked: false, remainingSeconds: 0 });
+      }
+    }
+    return false;
+  }, []);
+
+  // Update countdown timer
+  useEffect(() => {
+    if (!clientLock.isLocked) return;
+
+    const interval = setInterval(() => {
+      const attempts = getStoredAttempts();
+      if (attempts.lockedUntil) {
+        const remaining = attempts.lockedUntil - Date.now();
+        if (remaining > 0) {
+          setClientLock({
+            isLocked: true,
+            remainingSeconds: Math.ceil(remaining / 1000),
+          });
+        } else {
+          clearStoredAttempts();
+          setClientLock({ isLocked: false, remainingSeconds: 0 });
+        }
+      }
+    }, 1000);
+
+    return () => clearInterval(interval);
+  }, [clientLock.isLocked]);
+
+  // Check authentication status on mount
+  const checkAuth = useCallback(async () => {
+    try {
+      const res = await fetch("/admin/auth/status");
+      if (res.ok) {
+        const data = await res.json();
+        setAuthState({
+          isAuthenticated: data.authenticated,
+          isLoading: false,
+          authEnabled: data.auth_enabled,
+        });
+      } else {
+        setAuthState({
+          isAuthenticated: false,
+          isLoading: false,
+          authEnabled: true,
+        });
+      }
+    } catch {
+      setAuthState({
+        isAuthenticated: false,
+        isLoading: false,
+        authEnabled: true,
+      });
+    }
+  }, []);
+
+  useEffect(() => {
+    checkAuth();
+    checkClientLock();
+  }, [checkAuth, checkClientLock]);
+
+  // Login function
+  const login = useCallback(
+    async (key: string): Promise<LoginResult> => {
+      // Check client-side lock first
+      if (checkClientLock()) {
+        const attempts = getStoredAttempts();
+        const remaining = attempts.lockedUntil
+          ? Math.ceil((attempts.lockedUntil - Date.now()) / 1000)
+          : 60;
+        return {
+          success: false,
+          error: "Too many failed attempts. Please try again later.",
+          locked: true,
+          remaining_seconds: remaining,
+        };
+      }
+
+      try {
+        const res = await fetch("/admin/login", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ key }),
+        });
+
+        const data = await res.json();
+
+        if (data.success) {
+          // Clear failed attempts on success
+          clearStoredAttempts();
+          setClientLock({ isLocked: false, remainingSeconds: 0 });
+          setAuthState((prev) => ({ ...prev, isAuthenticated: true }));
+          return { success: true };
+        }
+
+        // Record failed attempt client-side
+        const attempts = getStoredAttempts();
+        attempts.count++;
+
+        if (attempts.count >= MAX_ATTEMPTS) {
+          attempts.lockedUntil = Date.now() + LOCK_DURATION_MS;
+          setClientLock({ isLocked: true, remainingSeconds: 60 });
+        }
+
+        setStoredAttempts(attempts);
+
+        return {
+          success: false,
+          error: data.error || "Invalid key",
+          locked: data.locked || attempts.count >= MAX_ATTEMPTS,
+          remaining_seconds: data.remaining_seconds || 60,
+        };
+      } catch (err) {
+        return {
+          success: false,
+          error: err instanceof Error ? err.message : "Login failed",
+        };
+      }
+    },
+    [checkClientLock]
+  );
+
+  // Logout function
+  const logout = useCallback(async () => {
+    try {
+      await fetch("/admin/logout", { method: "POST" });
+    } catch {
+      // Ignore errors
+    }
+    setAuthState((prev) => ({ ...prev, isAuthenticated: false }));
+  }, []);
+
+  return {
+    ...authState,
+    ...clientLock,
+    login,
+    logout,
+    checkAuth,
+  };
+}

--- a/cmd/relay-server/frontend/src/pages/Admin.tsx
+++ b/cmd/relay-server/frontend/src/pages/Admin.tsx
@@ -1,8 +1,14 @@
+import { useEffect } from "react";
+import { useNavigate } from "react-router-dom";
 import { SsgoiTransition } from "@ssgoi/react";
 import { useAdmin } from "@/hooks/useAdmin";
+import { useAuth } from "@/hooks/useAuth";
 import { ServerListView } from "@/components/ServerListView";
 
 export function Admin() {
+  const navigate = useNavigate();
+  const { isAuthenticated, isLoading: authLoading, logout } = useAuth();
+
   const {
     filteredServers,
     availableTags,
@@ -31,6 +37,26 @@ export function Admin() {
     handleBulkDeny,
     handleBulkBan,
   } = useAdmin();
+
+  // Redirect to login if not authenticated
+  useEffect(() => {
+    if (!authLoading && !isAuthenticated) {
+      navigate("/admin/login", { replace: true });
+    }
+  }, [authLoading, isAuthenticated, navigate]);
+
+  const handleLogout = async () => {
+    await logout();
+    navigate("/admin/login", { replace: true });
+  };
+
+  if (authLoading) {
+    return <div className="p-8 text-foreground">Checking authentication...</div>;
+  }
+
+  if (!isAuthenticated) {
+    return null; // Will redirect
+  }
 
   if (loading) return <div className="p-8 text-foreground">Loading...</div>;
   if (error) return <div className="p-8 text-red-500">Error: {error}</div>;
@@ -65,6 +91,7 @@ export function Admin() {
         onBulkApprove={handleBulkApprove}
         onBulkDeny={handleBulkDeny}
         onBulkBan={handleBulkBan}
+        onLogout={handleLogout}
       />
     </SsgoiTransition>
   );

--- a/cmd/relay-server/frontend/src/pages/AdminLogin.tsx
+++ b/cmd/relay-server/frontend/src/pages/AdminLogin.tsx
@@ -1,0 +1,178 @@
+import { useState, useEffect, FormEvent } from "react";
+import { useNavigate } from "react-router-dom";
+import { KeyRound, ShieldCheck } from "lucide-react";
+import { useAuth } from "@/hooks/useAuth";
+
+export function AdminLogin() {
+  const navigate = useNavigate();
+  const {
+    isAuthenticated,
+    isLoading,
+    authEnabled,
+    isLocked,
+    remainingSeconds,
+    login,
+  } = useAuth();
+
+  const [key, setKey] = useState("");
+  const [error, setError] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+
+  // Redirect if already authenticated
+  useEffect(() => {
+    if (!isLoading && isAuthenticated) {
+      navigate("/admin", { replace: true });
+    }
+  }, [isAuthenticated, isLoading, navigate]);
+
+  // Show auth not enabled message
+  useEffect(() => {
+    if (!isLoading && !authEnabled) {
+      setError(
+        "Admin authentication is not configured. Set ADMIN_SECRET_KEY in your environment."
+      );
+    }
+  }, [isLoading, authEnabled]);
+
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault();
+    if (!key.trim() || isLocked || submitting) return;
+
+    setSubmitting(true);
+    setError("");
+
+    const result = await login(key);
+
+    setSubmitting(false);
+
+    if (result.success) {
+      navigate("/admin", { replace: true });
+    } else {
+      setError(result.error || "Login failed");
+    }
+  };
+
+  if (isLoading) {
+    return (
+      <div className="min-h-screen bg-background flex items-center justify-center">
+        <div className="text-muted-foreground">Loading...</div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="relative flex h-auto min-h-screen w-full flex-col">
+      <div className="flex h-full grow flex-col">
+        <div className="flex flex-1 justify-center py-5">
+          <div className="flex flex-col w-full max-w-6xl flex-1 px-4 md:px-8">
+            {/* Header */}
+            <header className="flex items-center justify-between whitespace-nowrap px-4 sm:px-6 py-3">
+              <div className="flex items-center gap-4 text-foreground">
+                <div className="text-primary size-6">
+                  <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    width="24"
+                    height="24"
+                    viewBox="0 0 906.26 1457.543"
+                  >
+                    <path
+                      fill="#17C0E9"
+                      d="M254.854 137.158c-34.46 84.407-88.363 149.39-110.934 245.675 90.926-187.569 308.397-483.654 554.729-348.685 135.487 74.216 194.878 270.78 206.058 467.566 21.924 385.996-190.977 853.604-467.585 943.057-174.879 56.543-307.375-86.447-364.527-198.115-176.498-344.82 2.041-910.077 182.259-1109.498zm198.13 7.918C202.61 280.257 4.622 968.542 207.322 1270.414c51.713 77.029 194.535 160.648 285.294 71.318-209.061 31.529-288.389-176.143-301.145-340.765 31.411 147.743 139.396 326.12 309.075 253.588 251.957-107.723 376.778-648.46 269.433-966.817 22.394 134.616 15.572 317.711-47.551 412.087 86.655-230.615 7.903-704.478-269.444-554.749z"
+                    ></path>
+                  </svg>
+                </div>
+                <h2 className="text-foreground text-lg font-bold leading-tight tracking-[-0.015em]">
+                  PORTAL ADMIN
+                </h2>
+              </div>
+            </header>
+
+            {/* Main Content */}
+            <main className="flex flex-1 flex-col items-center justify-center py-16">
+              <div className="flex w-full max-w-md flex-col items-center gap-8 rounded-xl bg-card p-8 shadow-lg">
+                {/* Icon and Title */}
+                <div className="flex flex-col items-center gap-2 text-center">
+                  <ShieldCheck className="w-10 h-10 text-primary" />
+                  <h1 className="text-2xl font-bold text-foreground">
+                    Admin Access
+                  </h1>
+                  <p className="text-muted-foreground">
+                    Enter your secret key to manage servers.
+                  </p>
+                </div>
+
+                {/* Form */}
+                <form
+                  onSubmit={handleSubmit}
+                  className="flex w-full flex-col gap-6"
+                >
+                  <div className="flex flex-col gap-2">
+                    <label
+                      className="text-sm font-medium text-muted-foreground"
+                      htmlFor="admin-key"
+                    >
+                      ADMIN_SECRET_KEY
+                    </label>
+                    <div className="relative">
+                      <KeyRound className="absolute left-3 top-1/2 -translate-y-1/2 w-5 h-5 text-muted-foreground" />
+                      <input
+                        id="admin-key"
+                        type="password"
+                        placeholder="Enter your secret key"
+                        value={key}
+                        onChange={(e) => setKey(e.target.value)}
+                        disabled={isLocked || submitting || !authEnabled}
+                        autoFocus
+                        className="h-12 w-full rounded-lg border-none bg-secondary pl-10 pr-4 text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-primary/50"
+                      />
+                    </div>
+                  </div>
+
+                  {/* Error Message */}
+                  {error && (
+                    <div className="text-destructive text-sm text-center bg-destructive/10 p-3 rounded-md">
+                      {error}
+                    </div>
+                  )}
+
+                  {/* Lock Message */}
+                  {isLocked && (
+                    <div className="text-amber-500 text-sm text-center bg-amber-500/10 p-3 rounded-md">
+                      Too many failed attempts. Please wait {remainingSeconds}{" "}
+                      seconds.
+                    </div>
+                  )}
+
+                  {/* Submit Button */}
+                  <button
+                    type="submit"
+                    disabled={
+                      !key.trim() || isLocked || submitting || !authEnabled
+                    }
+                    className="flex h-12 w-full cursor-pointer items-center justify-center overflow-hidden rounded-lg bg-primary text-base font-bold text-white transition-colors hover:bg-primary/90 disabled:opacity-50 disabled:cursor-not-allowed"
+                  >
+                    <span className="truncate">
+                      {submitting
+                        ? "Authenticating..."
+                        : isLocked
+                        ? `Wait ${remainingSeconds}s`
+                        : "Login"}
+                    </span>
+                  </button>
+                </form>
+
+                {/* Back Link */}
+                <a
+                  href="/"
+                  className="text-sm text-muted-foreground hover:text-foreground transition-colors"
+                >
+                  Back to Home
+                </a>
+              </div>
+            </main>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/cmd/relay-server/manager/auth_manager.go
+++ b/cmd/relay-server/manager/auth_manager.go
@@ -1,0 +1,184 @@
+package manager
+
+import (
+	"crypto/rand"
+	"crypto/subtle"
+	"encoding/hex"
+	"sync"
+	"time"
+)
+
+const (
+	maxFailedAttempts = 3
+	lockDuration      = 1 * time.Minute
+	sessionDuration   = 24 * time.Hour
+)
+
+// AuthManager manages admin authentication with rate limiting
+type AuthManager struct {
+	secretKey    string
+	mu           sync.RWMutex
+	failedLogins map[string]*loginAttempt // IP -> attempt info
+	sessions     map[string]time.Time     // token -> expiry
+}
+
+type loginAttempt struct {
+	count    int
+	lockedAt time.Time
+}
+
+// NewAuthManager creates a new AuthManager with the given secret key
+func NewAuthManager(secretKey string) *AuthManager {
+	return &AuthManager{
+		secretKey:    secretKey,
+		failedLogins: make(map[string]*loginAttempt),
+		sessions:     make(map[string]time.Time),
+	}
+}
+
+// IsIPLocked checks if an IP is currently locked out
+func (m *AuthManager) IsIPLocked(ip string) bool {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	attempt, exists := m.failedLogins[ip]
+	if !exists {
+		return false
+	}
+
+	if attempt.count >= maxFailedAttempts {
+		// Check if lock has expired
+		if time.Since(attempt.lockedAt) < lockDuration {
+			return true
+		}
+	}
+
+	return false
+}
+
+// GetLockRemainingSeconds returns the remaining seconds until the IP is unlocked
+func (m *AuthManager) GetLockRemainingSeconds(ip string) int {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	attempt, exists := m.failedLogins[ip]
+	if !exists {
+		return 0
+	}
+
+	if attempt.count >= maxFailedAttempts {
+		remaining := lockDuration - time.Since(attempt.lockedAt)
+		if remaining > 0 {
+			return int(remaining.Seconds())
+		}
+	}
+
+	return 0
+}
+
+// RecordFailedLogin records a failed login attempt and returns true if the IP is now locked
+func (m *AuthManager) RecordFailedLogin(ip string) bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	attempt, exists := m.failedLogins[ip]
+	if !exists {
+		attempt = &loginAttempt{}
+		m.failedLogins[ip] = attempt
+	}
+
+	// Reset if lock has expired
+	if attempt.count >= maxFailedAttempts && time.Since(attempt.lockedAt) >= lockDuration {
+		attempt.count = 0
+	}
+
+	attempt.count++
+
+	if attempt.count >= maxFailedAttempts {
+		attempt.lockedAt = time.Now()
+		return true
+	}
+
+	return false
+}
+
+// ResetFailedLogin resets the failed login count for an IP
+func (m *AuthManager) ResetFailedLogin(ip string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	delete(m.failedLogins, ip)
+}
+
+// ValidateKey checks if the provided key matches the secret key
+func (m *AuthManager) ValidateKey(key string) bool {
+	if m.secretKey == "" {
+		return false
+	}
+	return subtle.ConstantTimeCompare([]byte(key), []byte(m.secretKey)) == 1
+}
+
+// HasSecretKey returns true if a secret key is configured
+func (m *AuthManager) HasSecretKey() bool {
+	return m.secretKey != ""
+}
+
+// CreateSession creates a new session and returns the token
+func (m *AuthManager) CreateSession() string {
+	token := generateToken()
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.sessions[token] = time.Now().Add(sessionDuration)
+
+	// Clean up expired sessions
+	m.cleanupExpiredSessions()
+
+	return token
+}
+
+// ValidateSession checks if a session token is valid
+func (m *AuthManager) ValidateSession(token string) bool {
+	if token == "" {
+		return false
+	}
+
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	expiry, exists := m.sessions[token]
+	if !exists {
+		return false
+	}
+
+	return time.Now().Before(expiry)
+}
+
+// DeleteSession removes a session
+func (m *AuthManager) DeleteSession(token string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	delete(m.sessions, token)
+}
+
+// cleanupExpiredSessions removes expired sessions (must be called with lock held)
+func (m *AuthManager) cleanupExpiredSessions() {
+	now := time.Now()
+	for token, expiry := range m.sessions {
+		if now.After(expiry) {
+			delete(m.sessions, token)
+		}
+	}
+}
+
+// generateToken generates a secure random token
+func generateToken() string {
+	bytes := make([]byte, 32)
+	if _, err := rand.Read(bytes); err != nil {
+		// Fallback to timestamp-based token (less secure but functional)
+		return hex.EncodeToString([]byte(time.Now().String()))
+	}
+	return hex.EncodeToString(bytes)
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,7 @@ services:
       PORTAL_URL: ${PORTAL_URL:-http://localhost:${PORTAL_PORT:-4017}}
       PORTAL_APP_URL: ${PORTAL_APP_URL:-http://*.localhost:${PORTAL_PORT:-4017}}
       BOOTSTRAP_URIS: ${BOOTSTRAP_URIS:-ws://localhost:${PORTAL_PORT:-4017}/relay}
+      ADMIN_SECRET_KEY: ${ADMIN_SECRET_KEY:-}
     ports:
       - "4017:4017"
     restart: unless-stopped


### PR DESCRIPTION
- Replace localhost-based access with ADMIN_SECRET_KEY authentication
- Add cookie-based session management with secure token generation
- Implement rate limiting (3 failed attempts = 1 min lockout) on both client and server
- Create /admin/login page with new card-style UI design
- Add logout button with tooltip in admin header