### PR TITLE
docs: add nginx reverse proxy deployment examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,13 @@ See [portal-toys](https://github.com/gosuda/portal-toys) for more examples.
 See [docs/architecture.md](docs/architecture.md).
 For architecture decisions, see [docs/adr/README.md](docs/adr/README.md).
 
+## Examples
+
+| Example | Description |
+|---------|-------------|
+| [nginx reverse proxy](docs/examples/nginx-proxy/) | Deploy Portal behind nginx with L4 SNI routing and TLS termination |
+| [nginx + multi-service](docs/examples/nginx-proxy-multi-service/) | Run Portal alongside other web services behind a single nginx instance |
+
 ## Contributing
 
 We welcome contributions from the community!

--- a/docs/examples/nginx-proxy-multi-service/docker-compose.yaml
+++ b/docs/examples/nginx-proxy-multi-service/docker-compose.yaml
@@ -1,0 +1,118 @@
+# Portal relay + multiple services — docker compose deployment example.
+#
+# This example shows how to run Portal alongside other web services
+# behind a single nginx instance on the same host.
+#
+# Architecture:
+#   nginx:443 (L4 stream, ssl_preread)
+#     ├─ portal.example.com    → portal:4017  (TLS passthrough, admin/API)
+#     ├─ *.portal.example.com  → portal:443   (TLS passthrough, tenant SNI)
+#     └─ everything else       → nginx:8443   (L7, TLS termination)
+#           ├─ app-a.example.com → app-a-frontend:3000 / app-a-api:8000
+#           └─ app-b.example.com → app-b-frontend:3000 / app-b-api:8001
+#
+# Prerequisites:
+#   1. Copy .env.example to .env and set all required values.
+#   2. Place TLS certificates in ./certs/:
+#        - Portal: managed by portal itself (ACME via KEYLESS_DIR)
+#        - Other services: app_a_fullchain.pem, app_a_privkey.pem, etc.
+#   3. Create the portal-certs directory with correct ownership (UID 65532 = nonroot in distroless):
+#        mkdir -p ./portal-certs
+#        sudo chown 65532:65532 ./portal-certs
+#        chmod 755 ./portal-certs
+#   4. Start all services:
+#        docker compose up -d
+
+services:
+
+  # ─── nginx ──────────────────────────────────────────────────────────────────
+  # Single entry point for all traffic (ports 80/443).
+  # Routes portal traffic via L4 SNI passthrough.
+  # Terminates TLS and proxies for all other services via L7.
+  nginx:
+    image: nginx:stable-alpine
+    container_name: nginx
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - ./nginx.conf:/etc/nginx/nginx.conf:ro
+      - ./certs:/etc/certs:ro
+    depends_on:
+      - portal
+      - app-a-api
+      - app-a-frontend
+    restart: unless-stopped
+    networks:
+      - default
+      - app-a-network
+      - app-b-network
+
+  # ─── portal relay ───────────────────────────────────────────────────────────
+  # NAT-traversal relay. Ports are internal-only — nginx routes to them
+  # via the docker network (L4 SNI passthrough, no TLS termination by nginx).
+  portal:
+    image: ghcr.io/gosuda/portal:2
+    container_name: portal
+    environment:
+      PORTAL_URL: ${PORTAL_URL:-https://portal.example.com}
+      BOOTSTRAP_URIS: ${BOOTSTRAP_URIS:-https://portal.example.com}
+      API_PORT: ${API_PORT:-4017}
+      SNI_PORT: ${SNI_PORT:-443}
+      ADMIN_SECRET_KEY: ${ADMIN_SECRET_KEY:-}
+      KEYLESS_DIR: ${KEYLESS_DIR:-/portal-certs}
+      CLOUDFLARE_TOKEN: ${CLOUDFLARE_TOKEN:-}
+    volumes:
+      - ./portal-certs:/portal-certs
+    expose:
+      - "4017"
+      - "443"
+    restart: unless-stopped
+    networks:
+      - default
+
+  # ─── App A: backend ─────────────────────────────────────────────────────────
+  # Replace with your actual backend service image and config.
+  app-a-api:
+    image: your-registry/app-a-api:latest
+    container_name: app-a-api
+    # environment:
+    #   - DATABASE_URL=...
+    restart: unless-stopped
+    networks:
+      - app-a-network
+
+  # ─── App A: frontend ────────────────────────────────────────────────────────
+  app-a-frontend:
+    image: your-registry/app-a-frontend:latest
+    container_name: app-a-frontend
+    restart: unless-stopped
+    networks:
+      - app-a-network
+    depends_on:
+      - app-a-api
+
+  # ─── App B: backend ─────────────────────────────────────────────────────────
+  # Replace with your actual backend service image and config.
+  app-b-api:
+    image: your-registry/app-b-api:latest
+    container_name: app-b-api
+    restart: unless-stopped
+    networks:
+      - app-b-network
+
+  # ─── App B: frontend ────────────────────────────────────────────────────────
+  app-b-frontend:
+    image: your-registry/app-b-frontend:latest
+    container_name: app-b-frontend
+    restart: unless-stopped
+    networks:
+      - app-b-network
+    depends_on:
+      - app-b-api
+
+networks:
+  app-a-network:
+    driver: bridge
+  app-b-network:
+    driver: bridge

--- a/docs/examples/nginx-proxy-multi-service/nginx.conf
+++ b/docs/examples/nginx-proxy-multi-service/nginx.conf
@@ -1,0 +1,220 @@
+# Portal relay + multiple services — nginx reverse proxy configuration example.
+#
+# This example shows how to run Portal alongside other web services
+# behind a single nginx instance. nginx handles:
+#   1. L4 SNI routing for portal (base domain + subdomains)
+#   2. L7 TLS termination + reverse proxy for other services
+#
+# Replace the following domains with your own:
+#   portal.example.com   → Portal relay
+#   app-a.example.com    → Your first web application
+#   app-b.example.com    → Your second web application
+#
+# Traffic flow:
+#   :80  → redirect to HTTPS
+#   :443 → L4 SNI inspection (ssl_preread)
+#            portal.example.com    → portal:4017  (admin/API, TLS passthrough)
+#            *.portal.example.com  → portal:443   (tenant SNI passthrough)
+#            everything else       → 127.0.0.1:8443 (nginx L7, TLS termination)
+
+user nginx;
+worker_processes auto;
+error_log /var/log/nginx/error.log;
+pid /run/nginx.pid;
+
+include /usr/share/nginx/modules/*.conf;
+
+events {
+    worker_connections 1024;
+}
+
+# ─── L4: SNI-based TCP routing ────────────────────────────────────────────────
+# nginx peeks at the TLS ClientHello via ssl_preread to extract SNI without
+# terminating TLS.
+#
+# Portal base domain   → portal admin/API listener (TLS passthrough)
+# Portal subdomains    → portal SNI listener (raw TCP passthrough)
+# Everything else      → nginx L7 for TLS termination (other services)
+stream {
+    map $ssl_preread_server_name $backend {
+        # Portal base domain: TLS passthrough directly to portal admin listener.
+        portal.example.com             portal_admin;
+        # Portal tenant subdomains: raw TCP passthrough to portal SNI listener.
+        ~\.portal\.example\.com$       portal_sni;
+        # All other domains: forward to nginx L7 for TLS termination.
+        default                        local_https;
+    }
+
+    upstream portal_admin {
+        # Portal admin/API TLS listener. nginx does NOT terminate TLS here.
+        server portal:4017;
+    }
+
+    upstream portal_sni {
+        # Portal SNI listener. Relay routes by SNI and bridges raw TCP
+        # to the claimed reverse session. TLS is not terminated.
+        server portal:443;
+    }
+
+    upstream local_https {
+        # nginx's own L7 HTTPS listener for other services.
+        server 127.0.0.1:8443;
+    }
+
+    server {
+        listen 443;
+        ssl_preread on;
+        proxy_pass $backend;
+        proxy_socket_keepalive on;
+        proxy_connect_timeout 10s;
+        proxy_buffer_size 16k;
+        # Long timeout for portal reverse sessions (24 hours).
+        proxy_timeout 600s;
+    }
+}
+
+# ─── L7: TLS termination + reverse proxy for other services ──────────────────
+# This section handles TLS termination for non-portal domains.
+# Portal traffic never reaches this http block — it's handled entirely
+# by the stream block above via TLS passthrough.
+http {
+    log_format main '$remote_addr - $remote_user [$time_local] "$request" '
+                    '$status $body_bytes_sent "$http_referer" '
+                    '"$http_user_agent" "$http_x_forwarded_for"';
+
+    access_log /var/log/nginx/access.log main;
+
+    sendfile        on;
+    tcp_nopush      on;
+    tcp_nodelay     on;
+    keepalive_timeout 65;
+    types_hash_max_size 4096;
+
+    include      /etc/nginx/mime.types;
+    default_type application/octet-stream;
+
+    include /etc/nginx/conf.d/*.conf;
+
+    map $http_upgrade $connection_upgrade {
+        default upgrade;
+        ''      close;
+    }
+
+    # ─── Upstreams ────────────────────────────────────────────────────────────
+    # Define backend services here. Each upstream corresponds to a Docker
+    # service on the same docker network.
+
+    upstream app_a_backend {
+        server app-a-api:8000;
+        keepalive 32;
+    }
+
+    upstream app_a_frontend {
+        server app-a-frontend:3000;
+        keepalive 32;
+    }
+
+    upstream app_b_backend {
+        server app-b-api:8001;
+        keepalive 32;
+    }
+
+    upstream app_b_frontend {
+        server app-b-frontend:3000;
+        keepalive 32;
+    }
+
+    # ─── HTTP → HTTPS redirect ────────────────────────────────────────────────
+    server {
+        listen 80;
+        listen [::]:80;
+        server_name app-a.example.com app-b.example.com portal.example.com;
+        return 301 https://$host$request_uri;
+    }
+
+    # ─── app-a.example.com ────────────────────────────────────────────────────
+    server {
+        listen 8443 ssl;
+        listen [::]:8443 ssl;
+        server_name app-a.example.com;
+        server_tokens off;
+
+        ssl_certificate     /etc/certs/app_a_fullchain.pem;
+        ssl_certificate_key /etc/certs/app_a_privkey.pem;
+
+        gzip on;
+        gzip_vary on;
+        gzip_min_length 1024;
+        gzip_types text/plain text/css application/json application/javascript
+                   text/xml application/xml;
+
+        # API / backend endpoint (e.g. SSE or long-polling)
+        location /api {
+            proxy_pass http://app_a_backend/api;
+            proxy_http_version 1.1;
+            proxy_set_header Connection '';
+            proxy_buffering off;
+            proxy_cache off;
+            chunked_transfer_encoding off;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_read_timeout 86400s;
+            proxy_send_timeout 86400s;
+        }
+
+        # Frontend
+        location / {
+            proxy_pass http://app_a_frontend;
+            proxy_http_version 1.1;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+        }
+    }
+
+    # ─── app-b.example.com ────────────────────────────────────────────────────
+    server {
+        listen 8443 ssl;
+        listen [::]:8443 ssl;
+        server_name app-b.example.com;
+        server_tokens off;
+
+        ssl_certificate     /etc/certs/app_b_fullchain.pem;
+        ssl_certificate_key /etc/certs/app_b_privkey.pem;
+
+        gzip on;
+        gzip_vary on;
+        gzip_min_length 1024;
+        gzip_types text/plain text/css application/json application/javascript
+                   text/xml application/xml;
+
+        # API / backend endpoint
+        location /api {
+            proxy_pass http://app_b_backend/api;
+            proxy_http_version 1.1;
+            proxy_set_header Connection '';
+            proxy_buffering off;
+            proxy_cache off;
+            chunked_transfer_encoding off;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_read_timeout 86400s;
+            proxy_send_timeout 86400s;
+        }
+
+        # Frontend
+        location / {
+            proxy_pass http://app_b_frontend;
+            proxy_http_version 1.1;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+        }
+    }
+}

--- a/docs/examples/nginx-proxy/.env.example
+++ b/docs/examples/nginx-proxy/.env.example
@@ -1,0 +1,23 @@
+# Portal + nginx reverse proxy configuration
+# Copy this file to .env and fill in the values.
+
+# Public routing (no port — nginx handles :443 externally)
+PORTAL_URL=https://portal.example.com
+BOOTSTRAP_URIS=https://portal.example.com
+
+# Internal listener ports
+API_PORT=4017
+SNI_PORT=443
+
+# Admin secret for the /admin UI
+ADMIN_SECRET_KEY=
+
+# Cloudflare API token (Zone:Read + DNS:Edit) for portal ACME cert issuance
+CLOUDFLARE_TOKEN=
+
+# Portal's own keyless TLS certificate directory
+KEYLESS_DIR=/portal-certs
+
+# Trust forwarded headers from nginx (required behind reverse proxy)
+TRUST_PROXY_HEADERS=true
+TRUSTED_PROXY_CIDRS=

--- a/docs/examples/nginx-proxy/docker-compose.yaml
+++ b/docs/examples/nginx-proxy/docker-compose.yaml
@@ -1,0 +1,79 @@
+# Portal relay — nginx reverse proxy deployment example.
+# Replace "portal.example.com" with your actual domain throughout.
+#
+# Architecture:
+#   nginx:443  (L4 stream, ssl_preread)
+#     ├─ portal.example.com    → nginx:8443 (L7, TLS termination) → portal:4017
+#     └─ *.portal.example.com  → portal:443  (raw TCP SNI passthrough)
+#
+# Prerequisites:
+#   1. Copy .env.example to .env and set all required values.
+#   2. Place your TLS certificate files in ./certs/:
+#        ./certs/fullchain.pem
+#        ./certs/privkey.pem
+#   3. Create the portal-certs directory with correct ownership (UID 65532 = nonroot in distroless):
+#        mkdir -p ./portal-certs
+#        sudo chown 65532:65532 ./portal-certs
+#        chmod 755 ./portal-certs
+#   4. Start all services:
+#        docker compose up -d
+
+services:
+
+  # ─── nginx ──────────────────────────────────────────────────────────────────
+  # Handles all inbound traffic on ports 80 and 443.
+  # L4 stream block routes by SNI; L7 http block terminates TLS for root domain.
+  nginx:
+    image: nginx:stable-alpine
+    container_name: nginx
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - ./nginx.conf:/etc/nginx/nginx.conf:ro
+      - ./certs:/etc/nginx/certs:ro
+    depends_on:
+      - portal
+    restart: unless-stopped
+    networks:
+      - portal-net
+
+  # ─── portal relay ───────────────────────────────────────────────────────────
+  # Relay server. Ports are internal-only when behind nginx.
+  # nginx forwards raw TCP for tenant subdomains to portal:443.
+  # nginx proxies admin/API HTTP to portal:4017.
+  portal:
+    image: ghcr.io/gosuda/portal:2
+    container_name: portal
+    environment:
+      # Public-facing relay URL. nginx handles TLS on port 443 externally,
+      # so this URL should not include a port number.
+      PORTAL_URL: ${PORTAL_URL:-https://portal.example.com}
+      BOOTSTRAP_URIS: ${BOOTSTRAP_URIS:-https://portal.example.com}
+
+      # Internal listener ports (not exposed to host).
+      API_PORT: ${API_PORT:-4017}
+      SNI_PORT: ${SNI_PORT:-443}
+
+      # Admin secret for the /admin UI. Set a strong random value.
+      ADMIN_SECRET_KEY: ${ADMIN_SECRET_KEY:-}
+
+      # Trust X-Forwarded-For and X-Real-IP headers from nginx.
+      TRUST_PROXY_HEADERS: ${TRUST_PROXY_HEADERS:-true}
+      TRUSTED_PROXY_CIDRS: ${TRUSTED_PROXY_CIDRS:-}
+
+      # Portal's own ACME-managed TLS certificates for keyless signing.
+      KEYLESS_DIR: ${KEYLESS_DIR:-/portal-certs}
+      CLOUDFLARE_TOKEN: ${CLOUDFLARE_TOKEN:-}
+    volumes:
+      - ./portal-certs:/portal-certs
+    expose:
+      - "4017"
+      - "443"
+    restart: unless-stopped
+    networks:
+      - portal-net
+
+networks:
+  portal-net:
+    driver: bridge

--- a/docs/examples/nginx-proxy/nginx.conf
+++ b/docs/examples/nginx-proxy/nginx.conf
@@ -1,0 +1,138 @@
+# Portal relay — nginx reverse proxy configuration example.
+# Replace "portal.example.com" with your actual domain throughout.
+#
+# Traffic flow:
+#   :80  → redirect to HTTPS
+#   :443 → L4 SNI inspection (ssl_preread, no TLS termination)
+#            portal.example.com    → :8443 (nginx L7, terminates TLS) → portal:4017
+#            *.portal.example.com  → portal:443 (raw TCP passthrough, relay routes by SNI)
+
+events {
+    worker_connections 4096;
+}
+
+# ─── L4: SNI-based TCP routing ────────────────────────────────────────────────
+# nginx peeks at the TLS ClientHello via ssl_preread to extract SNI without
+# terminating TLS. Traffic is forwarded based on whether the SNI matches
+# the exact root domain or a wildcard subdomain.
+#
+# Root domain → nginx L7 listener (port 8443, TLS termination)
+# Subdomains  → portal SNI listener (port 443, raw TCP passthrough)
+stream {
+    map $ssl_preread_server_name $backend {
+        # Exact root host: forward to nginx L7 for TLS termination.
+        portal.example.com              admin_tls;
+        # Portal tenant subdomains: raw TCP passthrough to portal SNI listener.
+        ~\.portal\.example\.com$        portal_sni;
+        # Fallback (no matching SNI).
+        default                         admin_tls;
+    }
+
+    upstream admin_tls {
+        server 127.0.0.1:8443;
+    }
+
+    upstream portal_sni {
+        # Portal SNI listener. Relay routes by SNI and bridges raw TCP
+        # to the claimed reverse session. TLS is not terminated here.
+        server portal:443;
+    }
+
+    server {
+        listen 443;
+        ssl_preread on;
+        proxy_pass $backend;
+        proxy_connect_timeout 5s;
+        # Long timeout for persistent reverse sessions (24 hours).
+        proxy_timeout 86400s;
+    }
+}
+
+# ─── L7: TLS termination + admin/API proxy ────────────────────────────────────
+# nginx terminates TLS for the root domain only, then proxies HTTP/1.1 to
+# the portal admin/API listener on port 4017.
+#
+# HTTP/2 is intentionally disabled on this listener.
+# /sdk/connect depends on HTTP/1.1 connection hijacking semantics.
+# Do NOT add 'http2' to the listen directives below.
+http {
+    sendfile        on;
+    tcp_nopush      on;
+    tcp_nodelay     on;
+    keepalive_timeout 65;
+
+    include      /etc/nginx/mime.types;
+    default_type application/octet-stream;
+
+    gzip on;
+    gzip_vary on;
+    gzip_min_length 1024;
+    gzip_types text/plain text/css application/json application/javascript
+               text/xml application/xml application/xml+rss text/javascript;
+
+    # ── Root domain: admin/API/frontend ──────────────────────────────────────
+    server {
+        # Internal L7 listener. Receives traffic from the L4 stream block.
+        # Do NOT add 'http2' — /sdk/connect requires HTTP/1.1 hijacking.
+        listen 8443 ssl;
+        server_name portal.example.com;
+        server_tokens off;
+
+        ssl_certificate     /etc/nginx/certs/fullchain.pem;
+        ssl_certificate_key /etc/nginx/certs/privkey.pem;
+
+        ssl_protocols TLSv1.2 TLSv1.3;
+        ssl_ciphers HIGH:!aNULL:!MD5;
+        ssl_prefer_server_ciphers on;
+        ssl_session_cache shared:SSL:10m;
+        ssl_session_timeout 10m;
+
+        # ── /sdk/connect: reverse session establishment ──────────────────────
+        # The relay hijacks this HTTP/1.1 connection into a long-lived raw TCP
+        # reverse session. After hijacking, data flows as raw bytes.
+        # Buffering must be disabled; timeouts must be long.
+        location = /sdk/connect {
+            proxy_pass http://portal:4017;
+            proxy_http_version 1.1;
+
+            proxy_set_header Host              $host;
+            proxy_set_header X-Real-IP         $remote_addr;
+            proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto https;
+
+            # Pass through Upgrade and Connection headers for HTTP/1.1
+            # connection hijacking. The relay takes ownership of the connection
+            # after validating the lease and reverse token.
+            proxy_set_header Upgrade    $http_upgrade;
+            proxy_set_header Connection $http_connection;
+
+            # Disable all buffering. Once hijacked, data is raw TCP.
+            proxy_buffering          off;
+            proxy_request_buffering  off;
+
+            proxy_read_timeout  86400s;
+            proxy_send_timeout  86400s;
+        }
+
+        # ── All other admin/API and frontend routes ──────────────────────────
+        location / {
+            proxy_pass http://portal:4017;
+            proxy_http_version 1.1;
+
+            proxy_set_header Host              $host;
+            proxy_set_header X-Real-IP         $remote_addr;
+            proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto https;
+            proxy_set_header Connection "";
+
+            proxy_read_timeout 60s;
+        }
+    }
+
+    # ── HTTP → HTTPS redirect ────────────────────────────────────────────────
+    server {
+        listen 80;
+        server_name _;
+        return 301 https://$host$request_uri;
+    }
+}


### PR DESCRIPTION
Add two nginx configuration examples under docs/examples/:
- nginx-proxy: portal-only setup with L4 SNI routing and L7 TLS termination
- nginx-proxy-multi-service: portal alongside other web services behind a single nginx

Each example includes nginx.conf, docker-compose.yaml, and prerequisites
for directory ownership (UID 65532 distroless nonroot).
Add Examples section to README.md linking both examples.