### PR TITLE
feat(frontend): show latest badge on relay version

### DIFF
--- a/frontend/src/components/ServerListView.tsx
+++ b/frontend/src/components/ServerListView.tsx
@@ -42,6 +42,19 @@ interface OfficialRegistryDocument {
 const OFFICIAL_REGISTRY_SOURCE_URL =
   "https://raw.githubusercontent.com/gosuda/portal/main/registry.json";
 const REPOSITORY_URL = "https://github.com/gosuda/portal";
+const GITHUB_LATEST_RELEASE_URL =
+  "https://api.github.com/repos/gosuda/portal/releases/latest";
+
+async function fetchLatestReleaseVersion(): Promise<string> {
+  const response = await fetch(GITHUB_LATEST_RELEASE_URL, {
+    headers: { Accept: "application/vnd.github.v3+json" },
+  });
+  if (!response.ok) {
+    return "";
+  }
+  const data = (await response.json()) as { tag_name?: string };
+  return typeof data.tag_name === "string" ? data.tag_name.trim() : "";
+}
 
 async function loadOfficialRegistryRelay(
   relayURL: string,

--- a/frontend/src/components/ServerListView.tsx
+++ b/frontend/src/components/ServerListView.tsx
@@ -232,6 +232,7 @@ export function ServerListView({
   const [officialRegistryRelays, setOfficialRegistryRelays] = useState<
     OfficialRegistryRelay[] | null
   >(null);
+  const [latestReleaseVersion, setLatestReleaseVersion] = useState("");
   const [selectedIdentityKeys, setSelectedIdentityKeys] = useState<Set<string>>(
     new Set()
   );
@@ -314,6 +315,14 @@ export function ServerListView({
 
     let cancelled = false;
     setOfficialRegistryRelays(null);
+
+    void fetchLatestReleaseVersion()
+      .then((version) => {
+        if (!cancelled) {
+          setLatestReleaseVersion(version);
+        }
+      })
+      .catch(() => {});
 
     void loadOfficialRegistryRelayURLs(OFFICIAL_REGISTRY_SOURCE_URL)
       .then((relayURLs) => {
@@ -847,9 +856,17 @@ export function ServerListView({
                                     Disconnected
                                   </span>
                                 ) : relay.releaseVersion ? (
-                                  <span className="rounded-full bg-background px-2.5 py-1 text-[10px] font-semibold uppercase tracking-[0.18em] text-text-muted ring-1 ring-border">
-                                    {relay.releaseVersion}
-                                  </span>
+                                  <>
+                                    <span className="rounded-full bg-background px-2.5 py-1 text-[10px] font-semibold uppercase tracking-[0.18em] text-text-muted ring-1 ring-border">
+                                      {relay.releaseVersion}
+                                    </span>
+                                    {latestReleaseVersion &&
+                                      relay.releaseVersion === latestReleaseVersion && (
+                                        <span className="rounded-full bg-emerald-500/10 px-2.5 py-1 text-[10px] font-semibold uppercase tracking-[0.18em] text-emerald-600 ring-1 ring-emerald-500/30 dark:text-emerald-400 dark:ring-emerald-400/30">
+                                          Latest
+                                        </span>
+                                      )}
+                                  </>
                                 ) : null}
                               </div>
                             </div>


### PR DESCRIPTION
## Summary
- GitHub API에서 최신 릴리즈 태그를 가져오는 `fetchLatestReleaseVersion` 함수 추가
- Official Registry 릴레이의 버전이 최신 릴리즈와 일치하면 초록색 **Latest** 뱃지 표시
- 사용자가 어떤 릴레이가 최신 버전인지 한눈에 확인 가능

## Test plan
- [ ] Official Registry 섹션에서 릴레이 버전 옆에 Latest 뱃지가 표시되는지 확인
- [ ] 최신 버전이 아닌 릴레이에는 Latest 뱃지가 표시되지 않는지 확인
- [ ] GitHub API 요청 실패 시에도 기존 버전 표시가 정상 동작하는지 확인
- [ ] 다크 모드에서 Latest 뱃지 색상이 적절한지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)