### PR TITLE
fix: restore target param in expose-name hashing and fix React hook r…

### DIFF
--- a/frontend/src/hooks/useList.ts
+++ b/frontend/src/hooks/useList.ts
@@ -127,12 +127,18 @@ export function useList<T extends BaseServer>({
 
   useEffect(() => {
     const validIDs = new Set(servers.map((server) => server.id));
-    setFavorites((prev) => prev.filter((id) => validIDs.has(id)));
+    setFavorites((prev) => {
+      const next = prev.filter((id) => validIDs.has(id));
+      return next.length === prev.length ? prev : next;
+    });
   }, [servers]);
 
   useEffect(() => {
     const availableTagSet = new Set(availableTags);
-    setSelectedTags((prev) => prev.filter((tag) => availableTagSet.has(tag)));
+    setSelectedTags((prev) => {
+      const next = prev.filter((tag) => availableTagSet.has(tag));
+      return next.length === prev.length ? prev : next;
+    });
   }, [availableTags]);
 
   const filteredServers = useMemo(() => {

--- a/frontend/src/hooks/useTunnelCommand.ts
+++ b/frontend/src/hooks/useTunnelCommand.ts
@@ -76,7 +76,7 @@ interface TunnelCommandExtras {
 
 export function useTunnelCommand(extras: TunnelCommandExtras = {}) {
   const currentOrigin = useMemo(() => readCurrentOrigin(), []);
-  const nameSeed = useMemo(() => readTunnelNameSeed(), []);
+  const [nameSeed] = useState(readTunnelNameSeed);
 
   const [target, setTarget] = useState(DEFAULT_HOST);
   const [name, setName] = useState("");

--- a/frontend/src/lib/exposeName.test.ts
+++ b/frontend/src/lib/exposeName.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import { buildDefaultExposeName } from "@/lib/exposeName";
+
+// Cross-language parity vectors -- keep in sync with utils/identity_test.go
+const exposeNameVectors = [
+  { target: "3000", seed: "test_seed", expected: "bubble-cricket-beacon" },
+  { target: "", seed: "portal", expected: "zesty-beacon-sketch" },
+  { target: "http://localhost:8080", seed: "cli_abc", expected: "sprightly-rocket-zap" },
+  { target: "192.168.1.1:8080", seed: "web_xyz", expected: "velvet-yeti-march" },
+  { target: "localhost", seed: "cli_", expected: "misty-rocket-ripple" },
+] as const;
+
+describe("buildDefaultExposeName", () => {
+  it.each(exposeNameVectors)(
+    "generates $expected for target=$target seed=$seed",
+    ({ target, seed, expected }) => {
+      expect(buildDefaultExposeName(target, seed)).toBe(expected);
+    },
+  );
+});

--- a/sdk/expose.go
+++ b/sdk/expose.go
@@ -69,6 +69,7 @@ func Expose(ctx context.Context, cfg ExposeConfig) (*Exposure, error) {
 
 	identity, createdIdentity, err := utils.ResolveListenerIdentity(
 		types.Identity{Name: cfg.Name},
+		cfg.TargetAddr,
 		cfg.IdentityPath,
 		cfg.IdentityJSON,
 	)

--- a/utils/identity.go
+++ b/utils/identity.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net"
+	"net/url"
 	"os"
 	"strings"
 
@@ -198,10 +200,10 @@ func LoadOrCreateIdentity(path string, identity types.Identity) (types.Identity,
 	return loaded, true, nil
 }
 
-func ResolveListenerIdentity(identity types.Identity, identityPath, identityJSON string) (types.Identity, bool, error) {
+func ResolveListenerIdentity(identity types.Identity, target, identityPath, identityJSON string) (types.Identity, bool, error) {
 	identityPath = strings.TrimSpace(identityPath)
 	identityJSON = strings.TrimSpace(identityJSON)
-	resolvedName, err := resolveExposeName(identity.Name, identityPath, identityJSON)
+	resolvedName, err := resolveExposeName(identity.Name, target, identityPath, identityJSON)
 	if err != nil {
 		return types.Identity{}, false, err
 	}
@@ -336,7 +338,15 @@ var exposeNameClosers = []string{
 	"whirl", "wink", "zap", "zenith", "zip", "zoom", "zest", "zone",
 }
 
-func DefaultExposeName(rawSeed string) (string, error) {
+const (
+	defaultExposeTargetPort = "3000"
+	defaultExposeTargetHost = "127.0.0.1"
+)
+
+// DefaultExposeName generates a deterministic 3-word DNS label from a target
+// address and seed using FNV-1a hashing. The algorithm matches the frontend
+// implementation in frontend/src/lib/exposeName.ts:buildDefaultExposeName.
+func DefaultExposeName(target, rawSeed string) (string, error) {
 	seed := strings.TrimSpace(rawSeed)
 	if cut, ok := strings.CutPrefix(seed, "cli_"); ok {
 		seed = cut
@@ -345,7 +355,7 @@ func DefaultExposeName(rawSeed string) (string, error) {
 		seed = "portal"
 	}
 
-	input := []byte(seed)
+	input := []byte(seed + "|" + normalizeExposeTarget(target))
 	first := fnv1a32(input, 0x811c9dc5)
 	second := fnv1a32(input, 0x9e3779b9)
 	third := fnv1a32(input, 0x85ebca6b)
@@ -359,7 +369,58 @@ func DefaultExposeName(rawSeed string) (string, error) {
 	return NormalizeDNSLabel(label)
 }
 
-func resolveExposeName(name, identityPath, identityJSON string) (string, error) {
+// normalizeExposeTarget normalizes a target address for deterministic name
+// generation. Must match frontend/src/lib/exposeName.ts:normalizeExposeTarget.
+func normalizeExposeTarget(raw string) string {
+	trimmed := strings.TrimSpace(raw)
+	candidate := trimmed
+	if candidate == "" {
+		candidate = defaultExposeTargetPort
+	}
+
+	if isAllDigits(candidate) {
+		return defaultExposeTargetHost + ":" + candidate
+	}
+
+	if strings.Contains(candidate, "://") {
+		u, err := url.Parse(candidate)
+		if err != nil {
+			return candidate
+		}
+		if (u.Scheme == "http" || u.Scheme == "https") &&
+			u.Host != "" &&
+			(u.Path == "" || u.Path == "/") &&
+			u.RawQuery == "" &&
+			u.Fragment == "" {
+			return u.Host
+		}
+		return candidate
+	}
+
+	u, err := url.Parse("tcp://" + candidate)
+	if err != nil || u.Hostname() == "" {
+		return candidate
+	}
+	port := u.Port()
+	if port == "" {
+		port = "80"
+	}
+	return net.JoinHostPort(u.Hostname(), port)
+}
+
+func isAllDigits(s string) bool {
+	if s == "" {
+		return false
+	}
+	for _, c := range s {
+		if c < '0' || c > '9' {
+			return false
+		}
+	}
+	return true
+}
+
+func resolveExposeName(name, target, identityPath, identityJSON string) (string, error) {
 	if name = strings.TrimSpace(name); name != "" {
 		return name, nil
 	}
@@ -384,7 +445,7 @@ func resolveExposeName(name, identityPath, identityJSON string) (string, error) 
 		}
 	}
 
-	return DefaultExposeName(RandomID("cli_"))
+	return DefaultExposeName(target, RandomID("cli_"))
 }
 
 func fnv1a32(data []byte, seed uint32) uint32 {

--- a/utils/identity_test.go
+++ b/utils/identity_test.go
@@ -1,0 +1,36 @@
+package utils
+
+import "testing"
+
+// Cross-language parity vectors -- keep in sync with frontend/src/lib/exposeName.test.ts
+var exposeNameVectors = []struct {
+	target, seed, expectedNormalized, expectedName string
+}{
+	{"3000", "test_seed", "127.0.0.1:3000", "bubble-cricket-beacon"},
+	{"", "portal", "127.0.0.1:3000", "zesty-beacon-sketch"},
+	{"http://localhost:8080", "cli_abc", "localhost:8080", "sprightly-rocket-zap"},
+	{"192.168.1.1:8080", "web_xyz", "192.168.1.1:8080", "velvet-yeti-march"},
+	{"localhost", "cli_", "localhost:80", "misty-rocket-ripple"},
+}
+
+func TestNormalizeExposeTarget(t *testing.T) {
+	for _, v := range exposeNameVectors {
+		got := normalizeExposeTarget(v.target)
+		if got != v.expectedNormalized {
+			t.Errorf("normalizeExposeTarget(%q) = %q, want %q", v.target, got, v.expectedNormalized)
+		}
+	}
+}
+
+func TestDefaultExposeName(t *testing.T) {
+	for _, v := range exposeNameVectors {
+		got, err := DefaultExposeName(v.target, v.seed)
+		if err != nil {
+			t.Errorf("DefaultExposeName(%q, %q) error: %v", v.target, v.seed, err)
+			continue
+		}
+		if got != v.expectedName {
+			t.Errorf("DefaultExposeName(%q, %q) = %q, want %q", v.target, v.seed, got, v.expectedName)
+		}
+	}
+}


### PR DESCRIPTION
…egressions

Three blocking issues from code review:

1. DefaultExposeName dropped the target parameter when moved to utils/identity.go, breaking frontend-backend name parity. Restore target threading through ResolveListenerIdentity and align the backend to FNV-1a (matching the frontend algorithm). Add normalizeExposeTarget as a Go port of the frontend logic.

2. useTunnelCommand.ts wrapped readTunnelNameSeed (which writes to localStorage) in useMemo — a side-effect in a pure-computation hook. Revert to useState.

3. useList.ts setFavorites/setSelectedTags always returned new arrays from filter(), breaking referential stability and causing unnecessary re-renders. Restore length-based equality guards.

Cross-language parity tests added for expose-name generation (5 vectors validated in both Go and TypeScript).