### PR TITLE
fix(sdk): persist lease expiry for renewal

### DIFF
--- a/sdk/api_client.go
+++ b/sdk/api_client.go
@@ -46,6 +46,7 @@ type apiClient struct {
 	rootCAPEM        []byte
 	identity         types.Identity
 	accessToken      string
+	expiresAt        time.Time
 	metadata         types.LeaseMetadata
 	resolvedPublicIP string
 	sniPort          int
@@ -138,6 +139,7 @@ func (a *apiClient) registerLease(ctx context.Context, ttl time.Duration, udpEna
 
 	a.mu.Lock()
 	a.accessToken = resp.AccessToken
+	a.expiresAt = resp.ExpiresAt
 	a.sniPort = sniPort
 	a.mu.Unlock()
 	return resp, nil
@@ -226,6 +228,7 @@ func (a *apiClient) renewLease(ctx context.Context, ttl time.Duration) error {
 	a.mu.Lock()
 	if a.accessToken == accessToken {
 		a.accessToken = resp.AccessToken
+		a.expiresAt = resp.ExpiresAt
 	}
 	a.mu.Unlock()
 	return nil

--- a/sdk/listener.go
+++ b/sdk/listener.go
@@ -423,15 +423,10 @@ func (l *Listener) runRenewLoop(ctx context.Context) {
 }
 
 func (l *Listener) renewLease(ctx context.Context) error {
-	l.api.mu.RLock()
-	expiresAt := l.api.expiresAt
-	l.api.mu.RUnlock()
-
-	if time.Now().Before(expiresAt) {
+	if time.Now().Before(l.api.expiresAt) {
 		requestCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
 		err := l.api.renewLease(requestCtx, l.leaseTTL)
 		cancel()
-
 		if err == nil {
 			return nil
 		}

--- a/sdk/listener.go
+++ b/sdk/listener.go
@@ -423,22 +423,26 @@ func (l *Listener) runRenewLoop(ctx context.Context) {
 }
 
 func (l *Listener) renewLease(ctx context.Context) error {
-	requestCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
-	err := l.api.renewLease(requestCtx, l.leaseTTL)
-	cancel()
-	if err == nil {
-		return nil
-	}
-	if !errors.Is(err, &types.APIRequestError{Code: types.APIErrorCodeLeaseNotFound}) {
-		return err
+	l.api.mu.RLock()
+	expiresAt := l.api.expiresAt
+	l.api.mu.RUnlock()
+
+	if time.Now().Before(expiresAt) {
+		requestCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+		err := l.api.renewLease(requestCtx, l.leaseTTL)
+		cancel()
+
+		if err == nil {
+			return nil
+		}
+		if !errors.Is(err, &types.APIRequestError{Code: types.APIErrorCodeLeaseNotFound}) {
+			return err
+		}
 	}
 
-	requestCtx, cancel = context.WithTimeout(ctx, 10*time.Second)
+	requestCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
-	if err := l.registerAndConfigure(requestCtx); err != nil {
-		return err
-	}
-	return nil
+	return l.registerAndConfigure(requestCtx)
 }
 
 func (l *Listener) registerAndConfigure(ctx context.Context) error {


### PR DESCRIPTION
tunnel process가 suspend되었을 때 token expired되면 재등록이 필요 (MAC Sleep mode, SIGSTOP, etc...)
relay에서 내려주는 만료시간을 저장하고 만료된 토큰이면 재등록을 태움


### before
```
  10:39PM INF service ready at https://test-before.portal.thumbgo.kr address=0xBd886d4f948f905D5fA8ABb72713716B88215659
#  kill -STOP 30005 (tunnel process 정지, MacOS에서 suspend상태 재현임)
#  ...45초정도 지난 후 (토큰 만료시킴)
#  kill -CONT 30005
  10:36PM DBG operation failed; retrying error=EOF address=0xC66aff202FE2A1D48B67bcC93Ca5772dD7c1df97 operation="reverse session connect" relay_url=https://portal.thumbgo.kr retry_attempt=1 retry_count=0 retry_wait=3000
# 만료된 토큰으로 재접속을 시도하다가 계속하여 실패
  10:40PM DBG operation failed; retrying error="read tcp 172.21.250.110:57110->100.100.249.28:443: i/o timeout" address=0xBd886d4f948f905D5fA8ABb72713716B88215659 operation="reverse session connect" relay_url=https://portal.thumbgo.kr retry_attempt=1 retry_count=0
  retry_wait=3000
  10:40PM DBG operation failed; retrying error=EOF address=0xBd886d4f948f905D5fA8ABb72713716B88215659 operation="reverse session connect" relay_url=https://portal.thumbgo.kr retry_attempt=1 retry_count=0 retry_wait=3000
  10:40PM DBG operation failed; retrying error="unauthorized: unauthorized" address=0xBd886d4f948f905D5fA8ABb72713716B88215659 operation="reverse session connect" relay_url=https://portal.thumbgo.kr retry_attempt=2 retry_count=0 retry_wait=3000
  # curl -https://test-before.portal.thumbgo.kr
  # curl: (35) OpenSSL SSL_connect: SSL_ERROR_ZERO_RETURN in connection to test-before.portal.thumbgo.kr:443
  10:40PM DBG operation failed; retrying error="unauthorized: unauthorized" address=0xBd886d4f948f905D5fA8ABb72713716B88215659 operation="reverse session connect" relay_url=https://portal.thumbgo.kr retry_attempt=10 retry_count=0 retry_wait=3000
```

### after
```
  10:33PM INF service ready at https://test.portal.thumbgo.kr address=0xC66aff202FE2A1D48B67bcC93Ca5772dD7c1df97
#  kill -STOP 23052 (tunnel process 정지, MacOS에서 suspend상태 재현임)
#  ...45초정도 지난 후
#  kill -CONT 23052 
  10:36PM DBG operation failed; retrying error=EOF address=0xC66aff202FE2A1D48B67bcC93Ca5772dD7c1df97 operation="reverse session connect" relay_url=https://portal.thumbgo.kr retry_attempt=1 retry_count=0 retry_wait=3000
# 재연결됨
# curl https://test.portal.thumbgo.kr
  10:37PM INF exposure connection accepted conn_id=3 local_addr=172.21.250.110:55786 remote_addr=100.100.249.28:443
  10:37PM INF exposure connection closed conn_id=3 local_addr=172.21.250.110:55786 remote_addr=100.100.249.28:443
  10:37PM DBG tls passthrough self-probe passed address=0xC66aff202FE2A1D48B67bcC93Ca5772dD7c1df97 public_url=https://test.portal.thumbgo.kr relay_url=https://portal.thumbgo.kr
```
