### PR TITLE
fix(sdk): auto-recover tunnel after macOS sleep/wake cycle

### DIFF
--- a/portal/transport/datagram_client.go
+++ b/portal/transport/datagram_client.go
@@ -1,21 +1,12 @@
 package transport
 
 import (
-	"context"
 	"net"
-	"time"
 
 	"github.com/quic-go/quic-go"
-	"github.com/rs/zerolog/log"
 
 	"github.com/gosuda/portal-tunnel/v2/types"
-	"github.com/gosuda/portal-tunnel/v2/utils"
 )
-
-type ClientDatagramState struct {
-	Identity    types.Identity
-	AccessToken string
-}
 
 type ClientDatagram struct {
 	session *datagramSession
@@ -27,75 +18,14 @@ func NewClientDatagram(onReceiveError func(error)) *ClientDatagram {
 	}
 }
 
-func (d *ClientDatagram) RunLoop(
-	ctx context.Context,
-	currentState func() (ClientDatagramState, bool),
-	open func(context.Context, ClientDatagramState) (*quic.Conn, error),
-) {
-	for {
-		select {
-		case <-ctx.Done():
-			d.session.Stop("listener context closed")
-			return
-		default:
+func (d *ClientDatagram) Bind(conn *quic.Conn) (<-chan struct{}, error) {
+	if d == nil || d.session == nil {
+		if conn != nil {
+			_ = conn.CloseWithError(0, "listener closed")
 		}
-
-		state, ok := currentState()
-		if !ok {
-			if !utils.SleepOrDone(ctx, time.Second) {
-				d.session.Stop("listener context closed")
-				return
-			}
-			continue
-		}
-
-		conn, err := open(ctx, state)
-		if err != nil {
-			log.Info().
-				Err(err).
-				Str("component", "sdk-datagram-plane").
-				Str("address", state.Identity.Address).
-				Msg("quic datagram plane unavailable; retrying")
-			if !utils.SleepOrDone(ctx, 2*time.Second) {
-				d.session.Stop("listener context closed")
-				return
-			}
-			continue
-		}
-
-		log.Info().
-			Str("component", "sdk-datagram-plane").
-			Str("address", state.Identity.Address).
-			Str("remote_addr", conn.RemoteAddr().String()).
-			Msg("quic tunnel connected")
-
-		recvDone, err := d.session.Bind(conn)
-		if err != nil {
-			if ctx.Err() != nil {
-				return
-			}
-			log.Info().
-				Err(err).
-				Str("component", "sdk-datagram-plane").
-				Str("address", state.Identity.Address).
-				Msg("quic datagram plane did not bind cleanly; retrying")
-			if !utils.SleepOrDone(ctx, time.Second) {
-				return
-			}
-			continue
-		}
-
-		select {
-		case <-ctx.Done():
-			d.session.Stop("listener context closed")
-			return
-		case <-recvDone:
-		}
-
-		if !utils.SleepOrDone(ctx, time.Second) {
-			return
-		}
+		return nil, net.ErrClosed
 	}
+	return d.session.Bind(conn)
 }
 
 func (d *ClientDatagram) Accept(done <-chan struct{}) (types.DatagramFrame, error) {

--- a/portal/transport/stream_client.go
+++ b/portal/transport/stream_client.go
@@ -42,39 +42,15 @@ func (s *ClientStream) Accept(done <-chan struct{}) (net.Conn, error) {
 	}
 }
 
-func (s *ClientStream) RunLoop(
+func (s *ClientStream) RunSession(
 	ctx context.Context,
 	open func(context.Context) (net.Conn, error),
 	currentTLSConfig func() *tls.Config,
-	retry func(context.Context, string, error, int) bool,
-	resetRetries <-chan struct{},
-) {
-	var retries int
-
-	for {
-		// Drain any pending reset signals (e.g. from system wake) before
-		// evaluating retry budget. This is non-blocking so it never stalls.
-		select {
-		case <-resetRetries:
-			retries = 0
-		default:
-		}
-
-		claimed, err := s.runSession(ctx, open, currentTLSConfig)
-		switch {
-		case err == nil:
-			retries = 0
-		case errors.Is(err, context.Canceled), errors.Is(err, net.ErrClosed):
-			return
-		case claimed:
-			retries = 0
-		default:
-			retries++
-			if retry == nil || !retry(ctx, "reverse session connect", err, retries) {
-				return
-			}
-		}
+) (bool, error) {
+	if s == nil {
+		return false, net.ErrClosed
 	}
+	return s.runSession(ctx, open, currentTLSConfig)
 }
 
 func (s *ClientStream) ActiveSessions() int {

--- a/portal/transport/stream_client.go
+++ b/portal/transport/stream_client.go
@@ -47,10 +47,19 @@ func (s *ClientStream) RunLoop(
 	open func(context.Context) (net.Conn, error),
 	currentTLSConfig func() *tls.Config,
 	retry func(context.Context, string, error, int) bool,
+	resetRetries <-chan struct{},
 ) {
 	var retries int
 
 	for {
+		// Drain any pending reset signals (e.g. from system wake) before
+		// evaluating retry budget. This is non-blocking so it never stalls.
+		select {
+		case <-resetRetries:
+			retries = 0
+		default:
+		}
+
 		claimed, err := s.runSession(ctx, open, currentTLSConfig)
 		switch {
 		case err == nil:

--- a/sdk/api_client.go
+++ b/sdk/api_client.go
@@ -76,13 +76,23 @@ func newApiClient(relayURL string, cfg ListenerConfig) (*apiClient, error) {
 	}, nil
 }
 
-func (a *apiClient) close() {
-	if a == nil || a.httpClient == nil {
+func closeIdleHTTPClient(httpClient *http.Client) {
+	if httpClient == nil {
 		return
 	}
-	if transport, ok := a.httpClient.Transport.(*http.Transport); ok {
+	if transport, ok := httpClient.Transport.(*http.Transport); ok {
 		transport.CloseIdleConnections()
 	}
+}
+
+func (a *apiClient) close() {
+	if a == nil {
+		return
+	}
+	a.mu.RLock()
+	httpClient := a.httpClient
+	a.mu.RUnlock()
+	closeIdleHTTPClient(httpClient)
 }
 
 // resetTransport tears down the cached HTTP client and TLS config so the next
@@ -92,14 +102,23 @@ func (a *apiClient) resetTransport() {
 	if a == nil {
 		return
 	}
-	a.close()
+	a.mu.Lock()
+	httpClient := a.httpClient
 	a.httpClient = nil
 	a.rawTLSConfig = nil
+	a.mu.Unlock()
+	closeIdleHTTPClient(httpClient)
 }
 
 func (a *apiClient) registerLease(ctx context.Context, ttl time.Duration, udpEnabled, tcpEnabled bool) (types.RegisterResponse, error) {
 	if err := a.ensureHTTPClient(ctx); err != nil {
 		return types.RegisterResponse{}, err
+	}
+	a.mu.RLock()
+	httpClient := a.httpClient
+	a.mu.RUnlock()
+	if httpClient == nil {
+		return types.RegisterResponse{}, errors.New("relay http client is unavailable")
 	}
 
 	var challenge types.RegisterChallengeResponse
@@ -110,7 +129,7 @@ func (a *apiClient) registerLease(ctx context.Context, ttl time.Duration, udpEna
 		UDPEnabled: udpEnabled,
 		TCPEnabled: tcpEnabled,
 	}
-	if err := utils.HTTPDoAPIPath(ctx, a.httpClient, a.baseURL, http.MethodPost, types.PathSDKRegisterChallenge, challengeReq, nil, &challenge); err != nil {
+	if err := utils.HTTPDoAPIPath(ctx, httpClient, a.baseURL, http.MethodPost, types.PathSDKRegisterChallenge, challengeReq, nil, &challenge); err != nil {
 		return types.RegisterResponse{}, err
 	}
 
@@ -120,7 +139,7 @@ func (a *apiClient) registerLease(ctx context.Context, ttl time.Duration, udpEna
 	}
 
 	var resp types.RegisterResponse
-	if err := utils.HTTPDoAPIPath(ctx, a.httpClient, a.baseURL, http.MethodPost, types.PathSDKRegister, types.RegisterRequest{
+	if err := utils.HTTPDoAPIPath(ctx, httpClient, a.baseURL, http.MethodPost, types.PathSDKRegister, types.RegisterRequest{
 		ChallengeID:   challenge.ChallengeID,
 		SIWEMessage:   challenge.SIWEMessage,
 		SIWESignature: signature,
@@ -158,9 +177,12 @@ func (a *apiClient) registerLease(ctx context.Context, ttl time.Duration, udpEna
 }
 
 func (a *apiClient) ensureHTTPClient(ctx context.Context) error {
+	a.mu.RLock()
 	if a.httpClient != nil && a.rawTLSConfig != nil {
+		a.mu.RUnlock()
 		return nil
 	}
+	a.mu.RUnlock()
 
 	bootstrapCtx, cancel := context.WithTimeout(ctx, defaultDialTimeout+defaultHandshakeTimeout)
 	defer cancel()
@@ -170,16 +192,21 @@ func (a *apiClient) ensureHTTPClient(ctx context.Context) error {
 		return err
 	}
 	if err := a.ensureCompatible(ctx, httpClient); err != nil {
-		if transport, ok := httpClient.Transport.(*http.Transport); ok {
-			transport.CloseIdleConnections()
-		}
-		a.close()
+		closeIdleHTTPClient(httpClient)
 		return err
 	}
 
-	a.close()
+	a.mu.Lock()
+	if a.httpClient != nil && a.rawTLSConfig != nil {
+		a.mu.Unlock()
+		closeIdleHTTPClient(httpClient)
+		return nil
+	}
+	oldHTTPClient := a.httpClient
 	a.httpClient = httpClient
 	a.rawTLSConfig = rawTLSConfig
+	a.mu.Unlock()
+	closeIdleHTTPClient(oldHTTPClient)
 
 	return nil
 }
@@ -218,14 +245,18 @@ func (a *apiClient) renewLease(ctx context.Context, ttl time.Duration) error {
 	}
 
 	a.mu.RLock()
+	httpClient := a.httpClient
 	accessToken := a.accessToken
 	a.mu.RUnlock()
+	if httpClient == nil {
+		return errors.New("relay http client is unavailable")
+	}
 	if strings.TrimSpace(accessToken) == "" {
 		return errors.New("access token is not available")
 	}
 
 	var resp types.RenewResponse
-	if err := utils.HTTPDoAPIPath(ctx, a.httpClient, a.baseURL, http.MethodPost, types.PathSDKRenew, types.RenewRequest{
+	if err := utils.HTTPDoAPIPath(ctx, httpClient, a.baseURL, http.MethodPost, types.PathSDKRenew, types.RenewRequest{
 		AccessToken: accessToken,
 		TTL:         int(ttl / time.Second),
 		ReportedIP:  a.reportedIP(ctx),
@@ -247,10 +278,17 @@ func (a *apiClient) renewLease(ctx context.Context, ttl time.Duration) error {
 }
 
 func (a *apiClient) unregisterLease(ctx context.Context) error {
+	if err := a.ensureHTTPClient(ctx); err != nil {
+		return err
+	}
 	a.mu.RLock()
+	httpClient := a.httpClient
 	accessToken := a.accessToken
 	a.mu.RUnlock()
-	return utils.HTTPDoAPIPath(ctx, a.httpClient, a.baseURL, http.MethodPost, types.PathSDKUnregister, types.UnregisterRequest{
+	if httpClient == nil {
+		return errors.New("relay http client is unavailable")
+	}
+	return utils.HTTPDoAPIPath(ctx, httpClient, a.baseURL, http.MethodPost, types.PathSDKUnregister, types.UnregisterRequest{
 		AccessToken: accessToken,
 	}, nil, nil)
 }
@@ -259,10 +297,17 @@ func (a *apiClient) openReverseSession(ctx context.Context) (net.Conn, error) {
 	if err := a.ensureHTTPClient(ctx); err != nil {
 		return nil, err
 	}
+	a.mu.RLock()
+	rawTLSConfig := a.rawTLSConfig
+	accessToken := a.accessToken
+	a.mu.RUnlock()
+	if rawTLSConfig == nil {
+		return nil, errors.New("relay tls config is unavailable")
+	}
 
 	dialer := &tls.Dialer{
 		NetDialer: &net.Dialer{Timeout: a.dialTimeout},
-		Config:    a.rawTLSConfig.Clone(),
+		Config:    rawTLSConfig.Clone(),
 	}
 
 	conn, err := dialer.DialContext(ctx, "tcp", utils.EnsurePort(a.baseURL.Host))
@@ -276,9 +321,6 @@ func (a *apiClient) openReverseSession(ctx context.Context) (net.Conn, error) {
 		Host:   a.baseURL.Host,
 		Header: make(http.Header),
 	}
-	a.mu.RLock()
-	accessToken := a.accessToken
-	a.mu.RUnlock()
 	req.Header.Set(types.HeaderAccessToken, accessToken)
 	req.Header.Set("Connection", "keep-alive")
 
@@ -333,7 +375,15 @@ func (a *apiClient) openQUICSession(ctx context.Context, accessToken string) (*q
 		return nil, err
 	}
 
-	tlsConf := a.rawTLSConfig.Clone()
+	a.mu.RLock()
+	rawTLSConfig := a.rawTLSConfig
+	sniPort := a.sniPort
+	a.mu.RUnlock()
+	if rawTLSConfig == nil {
+		return nil, errors.New("relay tls config is unavailable")
+	}
+
+	tlsConf := rawTLSConfig.Clone()
 	tlsConf.NextProtos = []string{"portal-tunnel"}
 
 	quicConf := &quic.Config{
@@ -341,10 +391,6 @@ func (a *apiClient) openQUICSession(ctx context.Context, accessToken string) (*q
 		KeepAlivePeriod: 15 * time.Second,
 		MaxIdleTimeout:  60 * time.Second,
 	}
-
-	a.mu.RLock()
-	sniPort := a.sniPort
-	a.mu.RUnlock()
 
 	if sniPort <= 0 {
 		return nil, errors.New("sni port is not available")

--- a/sdk/api_client.go
+++ b/sdk/api_client.go
@@ -85,6 +85,18 @@ func (a *apiClient) close() {
 	}
 }
 
+// resetTransport tears down the cached HTTP client and TLS config so the next
+// API call creates fresh TCP connections. Call this after detecting a system
+// sleep/wake cycle where pooled connections are almost certainly dead.
+func (a *apiClient) resetTransport() {
+	if a == nil {
+		return
+	}
+	a.close()
+	a.httpClient = nil
+	a.rawTLSConfig = nil
+}
+
 func (a *apiClient) registerLease(ctx context.Context, ttl time.Duration, udpEnabled, tcpEnabled bool) (types.RegisterResponse, error) {
 	if err := a.ensureHTTPClient(ctx); err != nil {
 		return types.RegisterResponse{}, err

--- a/sdk/listener.go
+++ b/sdk/listener.go
@@ -11,7 +11,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/quic-go/quic-go"
 	"github.com/rs/zerolog/log"
 
 	"github.com/gosuda/portal-tunnel/v2/portal/discovery"
@@ -44,6 +43,7 @@ type Listener struct {
 	cancel context.CancelFunc
 	doneCh <-chan struct{}
 
+	readyTarget int
 	retryCount  int
 	retryWait   time.Duration
 	leaseTTL    time.Duration
@@ -56,13 +56,7 @@ type Listener struct {
 	registered   chan struct{}
 	closeOnce    sync.Once
 	registerOnce sync.Once
-
-	// wakeBroadcast is closed and replaced each time the renew loop detects
-	// a system sleep/wake cycle.  Stream RunLoops select on this channel to
-	// reset their retry counters so they don't exhaust budget on stale-conn
-	// errors that are really caused by the OS suspending the process.
-	wakeBroadcast chan struct{}
-	wakeMu        sync.Mutex
+	streamCancel context.CancelFunc
 
 	banMITM    bool
 	tcpEnabled bool
@@ -93,20 +87,20 @@ func NewListener(ctx context.Context, relayURL string, cfg ListenerConfig) (*Lis
 	}
 
 	l := &Listener{
-		doneCh:        listenerCtx.Done(),
-		cancel:        cancel,
-		api:           api,
-		registered:    make(chan struct{}),
-		wakeBroadcast: make(chan struct{}),
-		retryCount:    cfg.RetryCount,
-		retryWait:     retryWait,
-		leaseTTL:      leaseTTL,
-		renewBefore:   renewBefore,
-		identity:      api.identity.Copy(),
-		metadata:      cfg.Metadata.Copy(),
-		banMITM:       cfg.BanMITM,
-		tcpEnabled:    cfg.TCPEnabled,
-		relaySet:      cfg.relaySet,
+		doneCh:      listenerCtx.Done(),
+		cancel:      cancel,
+		api:         api,
+		registered:  make(chan struct{}),
+		readyTarget: readyTarget,
+		retryCount:  cfg.RetryCount,
+		retryWait:   retryWait,
+		leaseTTL:    leaseTTL,
+		renewBefore: renewBefore,
+		identity:    api.identity.Copy(),
+		metadata:    cfg.Metadata.Copy(),
+		banMITM:     cfg.BanMITM,
+		tcpEnabled:  cfg.TCPEnabled,
+		relaySet:    cfg.relaySet,
 	}
 	l.mitmManager = newMITMManager(listenerCtx, l)
 	l.stream = transport.NewClientStream(readyTarget, handshakeTimeout)
@@ -118,36 +112,22 @@ func NewListener(ctx context.Context, relayURL string, cfg ListenerConfig) (*Lis
 				Str("address", l.Address()).
 				Msg("quic datagram plane disconnected; waiting to reconnect")
 		})
-		go l.datagram.RunLoop(listenerCtx, l.currentDatagramState, func(ctx context.Context, state transport.ClientDatagramState) (*quic.Conn, error) {
-			return l.api.openQUICSession(ctx, state.AccessToken)
-		})
 	}
 
-	go l.runStartup(listenerCtx, readyTarget)
+	go l.runStartup(listenerCtx)
 	return l, nil
 }
 
-func (l *Listener) runStartup(ctx context.Context, readyTarget int) {
+func (l *Listener) runStartup(ctx context.Context) {
 	var retries int
 
 	for {
 		err := l.registerAndConfigure(ctx)
 		switch {
 		case err == nil:
-			for range readyTarget {
-				go l.stream.RunLoop(
-					ctx,
-					func(ctx context.Context) (net.Conn, error) {
-						return l.api.openReverseSession(ctx)
-					},
-					func() *tls.Config {
-						l.mu.Lock()
-						defer l.mu.Unlock()
-						return l.tlsConfig
-					},
-					l.retryOrClose,
-					l.wakeChannel(),
-				)
+			l.startStreamLoops(ctx)
+			if l.datagram != nil {
+				go l.runDatagramLoop(ctx)
 			}
 			go l.runRenewLoop(ctx)
 			publicURL := l.PublicURL()
@@ -194,6 +174,7 @@ func (l *Listener) Close() error {
 		identity := l.identity.Copy()
 		registered := l.hostname != ""
 		tlsCloser := l.tlsCloser
+		streamCancel := l.streamCancel
 		stream := l.stream
 		datagram := l.datagram
 		api := l.api
@@ -201,10 +182,14 @@ func (l *Listener) Close() error {
 		l.udpAddr = ""
 		l.tlsConfig = nil
 		l.tlsCloser = nil
+		l.streamCancel = nil
 		l.mu.Unlock()
 
 		if l.mitmManager != nil {
 			l.mitmManager.reset()
+		}
+		if streamCancel != nil {
+			streamCancel()
 		}
 
 		if stream != nil {
@@ -375,43 +360,154 @@ func (l *Listener) PublicURL() string {
 	}).String()
 }
 
-func (l *Listener) currentDatagramState() (transport.ClientDatagramState, bool) {
-	if l.datagram == nil {
-		return transport.ClientDatagramState{}, false
+func (l *Listener) startStreamLoops(parentCtx context.Context) {
+	if l.stream == nil || l.readyTarget <= 0 {
+		return
 	}
+
+	streamCtx, cancel := context.WithCancel(parentCtx)
 
 	l.mu.Lock()
-	defer l.mu.Unlock()
-
-	if l.api == nil || l.identity.Key() == "" || l.udpAddr == "" {
-		return transport.ClientDatagramState{}, false
+	if l.streamCancel != nil {
+		l.streamCancel()
 	}
-	l.api.mu.RLock()
-	accessToken := l.api.accessToken
-	l.api.mu.RUnlock()
+	l.streamCancel = cancel
+	readyTarget := l.readyTarget
+	l.mu.Unlock()
 
-	return transport.ClientDatagramState{
-		Identity:    l.identity.Copy(),
-		AccessToken: accessToken,
-	}, true
+	for range readyTarget {
+		go l.runReverseSessionLoop(streamCtx)
+	}
 }
 
-// notifyWake closes the current wakeBroadcast channel (waking all stream
-// RunLoops that select on it) and replaces it with a fresh channel.
-func (l *Listener) notifyWake() {
-	l.wakeMu.Lock()
-	ch := l.wakeBroadcast
-	l.wakeBroadcast = make(chan struct{})
-	l.wakeMu.Unlock()
-	close(ch)
+func (l *Listener) stopStreamLoops() {
+	l.mu.Lock()
+	cancel := l.streamCancel
+	l.streamCancel = nil
+	l.mu.Unlock()
+
+	if cancel != nil {
+		cancel()
+	}
 }
 
-// wakeChannel returns the current wake broadcast channel. Stream RunLoops
-// select on this; when it is closed they reset their retry counters.
-func (l *Listener) wakeChannel() <-chan struct{} {
-	l.wakeMu.Lock()
-	defer l.wakeMu.Unlock()
-	return l.wakeBroadcast
+func (l *Listener) runReverseSessionLoop(ctx context.Context) {
+	if l.stream == nil {
+		return
+	}
+
+	var retries int
+	for {
+		claimed, err := l.stream.RunSession(
+			ctx,
+			func(ctx context.Context) (net.Conn, error) {
+				return l.api.openReverseSession(ctx)
+			},
+			func() *tls.Config {
+				l.mu.Lock()
+				defer l.mu.Unlock()
+				return l.tlsConfig
+			},
+		)
+		switch {
+		case err == nil:
+			retries = 0
+		case errors.Is(err, context.Canceled), errors.Is(err, net.ErrClosed):
+			return
+		case claimed:
+			retries = 0
+		default:
+			retries++
+			if !l.retryOrClose(ctx, "reverse session connect", err, retries) {
+				return
+			}
+		}
+	}
+}
+
+func (l *Listener) runDatagramLoop(ctx context.Context) {
+	if l.datagram == nil {
+		return
+	}
+
+	for {
+		select {
+		case <-ctx.Done():
+			l.datagram.Close()
+			return
+		default:
+		}
+
+		l.mu.Lock()
+		api := l.api
+		identity := l.identity.Copy()
+		udpAddr := l.udpAddr
+		l.mu.Unlock()
+		if api == nil || identity.Key() == "" || udpAddr == "" {
+			if !utils.SleepOrDone(ctx, time.Second) {
+				l.datagram.Close()
+				return
+			}
+			continue
+		}
+		api.mu.RLock()
+		accessToken := api.accessToken
+		api.mu.RUnlock()
+		if strings.TrimSpace(accessToken) == "" {
+			if !utils.SleepOrDone(ctx, time.Second) {
+				l.datagram.Close()
+				return
+			}
+			continue
+		}
+
+		conn, err := api.openQUICSession(ctx, accessToken)
+		if err != nil {
+			log.Info().
+				Err(err).
+				Str("component", "sdk-datagram-plane").
+				Str("address", identity.Address).
+				Msg("quic datagram plane unavailable; retrying")
+			if !utils.SleepOrDone(ctx, 2*time.Second) {
+				l.datagram.Close()
+				return
+			}
+			continue
+		}
+
+		log.Info().
+			Str("component", "sdk-datagram-plane").
+			Str("address", identity.Address).
+			Str("remote_addr", conn.RemoteAddr().String()).
+			Msg("quic tunnel connected")
+
+		recvDone, err := l.datagram.Bind(conn)
+		if err != nil {
+			if ctx.Err() != nil {
+				return
+			}
+			log.Info().
+				Err(err).
+				Str("component", "sdk-datagram-plane").
+				Str("address", identity.Address).
+				Msg("quic datagram plane did not bind cleanly; retrying")
+			if !utils.SleepOrDone(ctx, time.Second) {
+				return
+			}
+			continue
+		}
+
+		select {
+		case <-ctx.Done():
+			l.datagram.Close()
+			return
+		case <-recvDone:
+		}
+
+		if !utils.SleepOrDone(ctx, time.Second) {
+			return
+		}
+	}
 }
 
 func (l *Listener) runRenewLoop(ctx context.Context) {
@@ -450,12 +546,13 @@ func (l *Listener) runRenewLoop(ctx context.Context) {
 				Str("address", l.Address()).
 				Msg("system sleep/wake detected; resetting transport and re-registering")
 
+			l.stopStreamLoops()
 			l.api.resetTransport()
-			l.notifyWake()
 
 			var retries int
 			for {
 				if err := l.registerAndConfigure(ctx); err == nil {
+					l.startStreamLoops(ctx)
 					break
 				} else if errors.Is(err, context.Canceled) || errors.Is(err, net.ErrClosed) {
 					return

--- a/sdk/listener.go
+++ b/sdk/listener.go
@@ -57,6 +57,13 @@ type Listener struct {
 	closeOnce    sync.Once
 	registerOnce sync.Once
 
+	// wakeBroadcast is closed and replaced each time the renew loop detects
+	// a system sleep/wake cycle.  Stream RunLoops select on this channel to
+	// reset their retry counters so they don't exhaust budget on stale-conn
+	// errors that are really caused by the OS suspending the process.
+	wakeBroadcast chan struct{}
+	wakeMu        sync.Mutex
+
 	banMITM    bool
 	tcpEnabled bool
 	identity   types.Identity
@@ -86,19 +93,20 @@ func NewListener(ctx context.Context, relayURL string, cfg ListenerConfig) (*Lis
 	}
 
 	l := &Listener{
-		doneCh:      listenerCtx.Done(),
-		cancel:      cancel,
-		api:         api,
-		registered:  make(chan struct{}),
-		retryCount:  cfg.RetryCount,
-		retryWait:   retryWait,
-		leaseTTL:    leaseTTL,
-		renewBefore: renewBefore,
-		identity:    api.identity.Copy(),
-		metadata:    cfg.Metadata.Copy(),
-		banMITM:     cfg.BanMITM,
-		tcpEnabled:  cfg.TCPEnabled,
-		relaySet:    cfg.relaySet,
+		doneCh:        listenerCtx.Done(),
+		cancel:        cancel,
+		api:           api,
+		registered:    make(chan struct{}),
+		wakeBroadcast: make(chan struct{}),
+		retryCount:    cfg.RetryCount,
+		retryWait:     retryWait,
+		leaseTTL:      leaseTTL,
+		renewBefore:   renewBefore,
+		identity:      api.identity.Copy(),
+		metadata:      cfg.Metadata.Copy(),
+		banMITM:       cfg.BanMITM,
+		tcpEnabled:    cfg.TCPEnabled,
+		relaySet:      cfg.relaySet,
 	}
 	l.mitmManager = newMITMManager(listenerCtx, l)
 	l.stream = transport.NewClientStream(readyTarget, handshakeTimeout)
@@ -138,6 +146,7 @@ func (l *Listener) runStartup(ctx context.Context, readyTarget int) {
 						return l.tlsConfig
 					},
 					l.retryOrClose,
+					l.wakeChannel(),
 				)
 			}
 			go l.runRenewLoop(ctx)
@@ -387,6 +396,24 @@ func (l *Listener) currentDatagramState() (transport.ClientDatagramState, bool) 
 	}, true
 }
 
+// notifyWake closes the current wakeBroadcast channel (waking all stream
+// RunLoops that select on it) and replaces it with a fresh channel.
+func (l *Listener) notifyWake() {
+	l.wakeMu.Lock()
+	ch := l.wakeBroadcast
+	l.wakeBroadcast = make(chan struct{})
+	l.wakeMu.Unlock()
+	close(ch)
+}
+
+// wakeChannel returns the current wake broadcast channel. Stream RunLoops
+// select on this; when it is closed they reset their retry counters.
+func (l *Listener) wakeChannel() <-chan struct{} {
+	l.wakeMu.Lock()
+	defer l.wakeMu.Unlock()
+	return l.wakeBroadcast
+}
+
 func (l *Listener) runRenewLoop(ctx context.Context) {
 	interval := l.leaseTTL / 2
 	if interval <= 0 {
@@ -399,9 +426,47 @@ func (l *Listener) runRenewLoop(ctx context.Context) {
 		interval = 30 * time.Second
 	}
 
+	const wakeThreshold = 10 * time.Second
+
 	for {
+		// Round(0) strips the monotonic clock reading so that
+		// time.Since uses wall-clock time.  The monotonic clock
+		// freezes during macOS sleep, so without this the elapsed
+		// duration would equal the timer interval, not real time.
+		before := time.Now().Round(0)
 		if !utils.SleepOrDone(ctx, interval) {
 			return
+		}
+		elapsed := time.Since(before)
+
+		// If the wall-clock jump is much larger than expected, the OS
+		// likely suspended the process (e.g. macOS lid close).  The
+		// server-side lease is almost certainly expired, so skip the
+		// normal renew and go straight to re-registration.
+		if elapsed > interval+wakeThreshold {
+			log.Info().
+				Dur("expected", interval).
+				Dur("actual", elapsed).
+				Str("address", l.Address()).
+				Msg("system sleep/wake detected; resetting transport and re-registering")
+
+			l.api.resetTransport()
+			l.notifyWake()
+
+			var retries int
+			for {
+				if err := l.registerAndConfigure(ctx); err == nil {
+					break
+				} else if errors.Is(err, context.Canceled) || errors.Is(err, net.ErrClosed) {
+					return
+				} else {
+					retries++
+					if !l.retryOrClose(ctx, "post-wake re-registration", err, retries) {
+						return
+					}
+				}
+			}
+			continue
 		}
 
 		var retries int
@@ -526,7 +591,23 @@ func (l *Listener) retryOrClose(ctx context.Context, operation string, err error
 			Msg("operation failed; retrying")
 	}
 
-	return utils.SleepOrDone(ctx, l.retryWait)
+	// Detect sleep/wake during the retry wait itself.  If the OS
+	// suspended the process, the renew loop will be re-registering
+	// concurrently.  Give it a moment to finish so the next attempt
+	// uses a fresh access token and transport.
+	// Round(0) forces wall-clock comparison (monotonic clock freezes
+	// during macOS sleep).
+	before := time.Now().Round(0)
+	ok := utils.SleepOrDone(ctx, l.retryWait)
+	if ok && time.Since(before) > l.retryWait+10*time.Second {
+		logger.Info().
+			Dur("expected", l.retryWait).
+			Dur("actual", time.Since(before)).
+			Msg("system sleep/wake detected during retry wait; pausing for re-registration")
+		// Wait briefly for the renew loop to complete re-registration.
+		utils.SleepOrDone(ctx, 3*time.Second)
+	}
+	return ok
 }
 
 type listenerAddr string


### PR DESCRIPTION
When the OS suspends the process (e.g. MacBook lid close), all timers
freeze while the server-side lease janitor keeps running and expires
the lease after 30s. After wake the client was left with stale TCP
connections and an expired access token, causing repeated i/o timeout
and unauthorized errors across all relays.

Detect sleep/wake via wall-clock gap (monotonic clock freezes during
sleep, so time.Now().Round(0) is used to force wall-clock comparison).
On detection: tear down dead HTTP transport, broadcast retry-counter
reset to stream RunLoops, and re-register the lease immediately.