### PR TITLE
Refactor relay discovery and state management

### DIFF
--- a/portal/api_server.go
+++ b/portal/api_server.go
@@ -176,7 +176,7 @@ func (s *Server) handleRelayDiscovery(w http.ResponseWriter, r *http.Request) {
 		OwnerAddress:        s.identity.Address,
 		Version:             1,
 		IssuedAt:            now,
-		ExpiresAt:           now.Add(2 * discovery.DiscoveryPollInterval),
+		ExpiresAt:           now.Add(discovery.DiscoveryDescriptorTTL),
 		APIHTTPSAddr:        s.cfg.PortalURL,
 		Discovery:           s.cfg.DiscoveryEnabled,
 		IngressTLSAddr:      ingressAddr,

--- a/portal/discovery/policy.go
+++ b/portal/discovery/policy.go
@@ -11,10 +11,11 @@ import (
 )
 
 type RelayPolicy interface {
-	SelectActive([]RelayState) []RelayState
+	SelectAggregate([]RelayState) []RelayState
+	SelectConfirmed([]RelayState) []RelayState
 	SelectPriority([]RelayState, ClientState) []string
 	OnConfirmed(RelayState) RelayState
-	OnHinted(RelayState) RelayState
+	OnUnconfirmed(RelayState) RelayState
 	OnFailure(RelayState, error, int) (RelayState, bool, string)
 	OnBanned(RelayState) RelayState
 }
@@ -23,14 +24,13 @@ type DefaultRelayPolicy struct{}
 
 const highDiscoveryRTTThreshold = 1 * time.Second
 
-func (p DefaultRelayPolicy) selectStates(states []RelayState, keep func(RelayState) bool) []RelayState {
-	now := time.Now().UTC()
+func (p DefaultRelayPolicy) SelectAggregate(states []RelayState) []RelayState {
 	out := make([]RelayState, 0, len(states))
 	for _, state := range states {
-		if !state.discoverable(now) {
+		if state.Banned {
 			continue
 		}
-		if !keep(state) {
+		if !state.Bootstrap && !state.hasDescriptor() {
 			continue
 		}
 		out = append(out, state)
@@ -41,14 +41,23 @@ func (p DefaultRelayPolicy) selectStates(states []RelayState, keep func(RelaySta
 	return out
 }
 
-func (p DefaultRelayPolicy) SelectActive(states []RelayState) []RelayState {
-	return p.selectStates(states, func(state RelayState) bool {
-		return state.Bootstrap || state.Confirmed
-	})
+func (p DefaultRelayPolicy) SelectConfirmed(states []RelayState) []RelayState {
+	selected := p.SelectAggregate(states)
+	out := make([]RelayState, 0, len(selected))
+	for _, state := range selected {
+		if !state.Confirmed {
+			continue
+		}
+		out = append(out, state)
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
 }
 
 func (p DefaultRelayPolicy) SelectPriority(states []RelayState, clientState ClientState) []string {
-	selected := p.SelectActive(states)
+	selected := p.SelectAggregate(states)
 	if len(selected) == 0 {
 		return nil
 	}
@@ -74,33 +83,33 @@ func (p DefaultRelayPolicy) SelectPriority(states []RelayState, clientState Clie
 	}
 
 	currentAuto := make([]string, 0, len(autoPool))
-	remainingAuto := make([]string, 0, len(autoPool))
+	confirmedAuto := make([]string, 0, len(autoPool))
 	highRTTAuto := make([]string, 0, len(autoPool))
-	penalizedAuto := make([]string, 0, len(autoPool))
+	remainingAuto := make([]string, 0, len(autoPool))
 	for _, state := range autoPool {
 		relayURL := state.Descriptor.APIHTTPSAddr
-		statePenalized := state.consecutiveFailures > 0 && !state.Reachable
 		switch {
-		case slices.Contains(clientState.ActiveRelayURLs, relayURL) && !statePenalized:
+		case slices.Contains(clientState.ActiveRelayURLs, relayURL):
 			currentAuto = append(currentAuto, relayURL)
-		case statePenalized:
-			penalizedAuto = append(penalizedAuto, relayURL)
-		case !state.DiscoveryRTTAt.IsZero() && state.DiscoveryRTT > highDiscoveryRTTThreshold:
+		case state.Confirmed && !state.DiscoveryRTTAt.IsZero() && state.DiscoveryRTT > highDiscoveryRTTThreshold:
 			highRTTAuto = append(highRTTAuto, relayURL)
+		case state.Confirmed:
+			confirmedAuto = append(confirmedAuto, relayURL)
 		default:
 			remainingAuto = append(remainingAuto, relayURL)
 		}
 	}
 
+	if len(confirmedAuto) > 1 {
+		rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+		rng.Shuffle(len(confirmedAuto), func(i, j int) {
+			confirmedAuto[i], confirmedAuto[j] = confirmedAuto[j], confirmedAuto[i]
+		})
+	}
 	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
 	if len(remainingAuto) > 1 {
 		rng.Shuffle(len(remainingAuto), func(i, j int) {
 			remainingAuto[i], remainingAuto[j] = remainingAuto[j], remainingAuto[i]
-		})
-	}
-	if len(penalizedAuto) > 1 {
-		rng.Shuffle(len(penalizedAuto), func(i, j int) {
-			penalizedAuto[i], penalizedAuto[j] = penalizedAuto[j], penalizedAuto[i]
 		})
 	}
 	if len(highRTTAuto) > 1 {
@@ -109,11 +118,11 @@ func (p DefaultRelayPolicy) SelectPriority(states []RelayState, clientState Clie
 		})
 	}
 
-	autoURLs := make([]string, 0, len(currentAuto)+len(remainingAuto)+len(highRTTAuto)+len(penalizedAuto))
+	autoURLs := make([]string, 0, len(currentAuto)+len(confirmedAuto)+len(highRTTAuto)+len(remainingAuto))
 	autoURLs = append(autoURLs, currentAuto...)
-	autoURLs = append(autoURLs, remainingAuto...)
+	autoURLs = append(autoURLs, confirmedAuto...)
 	autoURLs = append(autoURLs, highRTTAuto...)
-	autoURLs = append(autoURLs, penalizedAuto...)
+	autoURLs = append(autoURLs, remainingAuto...)
 	if clientState.MaxActiveRelays > 0 && len(autoURLs) > clientState.MaxActiveRelays {
 		autoURLs = autoURLs[:clientState.MaxActiveRelays]
 	}
@@ -131,20 +140,12 @@ func (DefaultRelayPolicy) OnConfirmed(state RelayState) RelayState {
 	if state.Banned {
 		return state
 	}
-	state.Reachable = true
 	state.Confirmed = true
-	state.consecutiveFailures = 0
 	return state
 }
 
-func (DefaultRelayPolicy) OnHinted(state RelayState) RelayState {
-	if state.Banned {
-		return state
-	}
-	state.Reachable = true
-	if !state.Confirmed {
-		state.consecutiveFailures = 0
-	}
+func (DefaultRelayPolicy) OnUnconfirmed(state RelayState) RelayState {
+	state.Confirmed = false
 	return state
 }
 
@@ -153,12 +154,16 @@ func (DefaultRelayPolicy) OnFailure(state RelayState, err error, recoveryFailure
 		return state, false, ""
 	}
 	state.consecutiveFailures++
-	expire := func(reason string) (RelayState, bool, string) {
-		if !state.Reachable {
-			return state, false, ""
+	backOff := func(reason string) (RelayState, bool, string) {
+		backoff := defaultDirectRecoveryBackoff
+		for extra := state.consecutiveFailures - recoveryFailures; extra > 0; extra-- {
+			if backoff >= maxDirectRecoveryBackoff/2 {
+				backoff = maxDirectRecoveryBackoff
+				break
+			}
+			backoff *= 2
 		}
-		state.Reachable = false
-		state.Confirmed = false
+		state.nextDirectRefreshAt = time.Now().UTC().Add(backoff)
 		return state, true, reason
 	}
 	var apiErr *types.APIRequestError
@@ -166,15 +171,16 @@ func (DefaultRelayPolicy) OnFailure(state RelayState, err error, recoveryFailure
 		(apiErr.StatusCode == http.StatusForbidden ||
 			apiErr.StatusCode == http.StatusNotFound ||
 			apiErr.StatusCode == http.StatusGone) {
-		return expire("status")
+		return backOff("status")
 	}
 	if state.consecutiveFailures >= recoveryFailures {
-		return expire("recovery")
+		return backOff("recovery")
 	}
 	return state, false, ""
 }
 
 func (DefaultRelayPolicy) OnBanned(state RelayState) RelayState {
 	state.Banned = true
+	state.Confirmed = false
 	return state
 }

--- a/portal/discovery/policy_test.go
+++ b/portal/discovery/policy_test.go
@@ -1,6 +1,7 @@
 package discovery
 
 import (
+	"errors"
 	"testing"
 	"time"
 
@@ -21,6 +22,7 @@ func mustPolicyRelayDescriptor(t *testing.T, relayName, relayURL string) types.R
 		IssuedAt:     now,
 		ExpiresAt:    now.Add(time.Hour),
 		APIHTTPSAddr: relayURL,
+		Discovery:    true,
 	})
 	if err != nil {
 		t.Fatalf("NormalizeDescriptor() error = %v", err)
@@ -46,7 +48,6 @@ func confirmedPolicyRelayState(t *testing.T, relayName, relayURL string) RelaySt
 
 	return RelayState{
 		Descriptor: mustPolicyRelayDescriptor(t, relayName, relayURL),
-		Reachable:  true,
 		Confirmed:  true,
 		LastSeenAt: time.Now().UTC(),
 	}
@@ -84,6 +85,93 @@ func TestSelectPriorityKeepsExplicitRelaysOutsideAutoLimit(t *testing.T) {
 	}
 }
 
+func TestSelectAggregateKeepsBootstrapRelayWhenDescriptorExpired(t *testing.T) {
+	policy := DefaultRelayPolicy{}
+	relayURL := "https://relay-bootstrap.example"
+
+	state := bootstrapPolicyRelayState(relayURL)
+	state.LastSeenAt = time.Now().UTC().Add(-time.Minute)
+	state.Descriptor.ExpiresAt = time.Now().UTC().Add(-time.Second)
+
+	selected := policy.SelectAggregate([]RelayState{state})
+
+	if len(selected) != 1 {
+		t.Fatalf("len(selected) = %d, want 1", len(selected))
+	}
+	if got := selected[0].Descriptor.APIHTTPSAddr; got != relayURL {
+		t.Fatalf("selected[0] = %q, want bootstrap relay %q", got, relayURL)
+	}
+}
+
+func TestSelectAggregateKeepsCollectedRelayEvenWhenNotAdvertisable(t *testing.T) {
+	policy := DefaultRelayPolicy{}
+	state := RelayState{
+		Descriptor: mustPolicyRelayDescriptor(t, "relay-a", "https://relay-a.example"),
+		LastSeenAt: time.Now().UTC().Add(-DiscoveryHintRetentionTTL).Add(-time.Hour),
+	}
+	state.Descriptor.Discovery = false
+	state.Descriptor.ExpiresAt = time.Now().UTC().Add(-time.Second)
+
+	selected := policy.SelectAggregate([]RelayState{state})
+
+	if len(selected) != 1 {
+		t.Fatalf("len(selected) = %d, want 1", len(selected))
+	}
+}
+
+func TestSelectAggregateIncludesHintedRelayWithoutConfirmation(t *testing.T) {
+	policy := DefaultRelayPolicy{}
+	state := RelayState{
+		Descriptor: mustPolicyRelayDescriptor(t, "relay-hinted", "https://relay-hinted.example"),
+		LastSeenAt: time.Now().UTC(),
+	}
+
+	selected := policy.SelectAggregate([]RelayState{state})
+
+	if len(selected) != 1 {
+		t.Fatalf("len(selected) = %d, want 1", len(selected))
+	}
+	if got := selected[0].Descriptor.APIHTTPSAddr; got != state.Descriptor.APIHTTPSAddr {
+		t.Fatalf("selected[0] = %q, want %q", got, state.Descriptor.APIHTTPSAddr)
+	}
+}
+
+func TestSelectAggregateSkipsBannedBootstrapRelay(t *testing.T) {
+	policy := DefaultRelayPolicy{}
+	state := bootstrapPolicyRelayState("https://relay-banned.example")
+	state.Banned = true
+
+	selected := policy.SelectAggregate([]RelayState{state})
+
+	if len(selected) != 0 {
+		t.Fatalf("len(selected) = %d, want 0", len(selected))
+	}
+}
+
+func TestSelectConfirmedKeepsOnlyConfirmedAggregateRelays(t *testing.T) {
+	policy := DefaultRelayPolicy{}
+	confirmed := confirmedPolicyRelayState(t, "relay-confirmed", "https://relay-confirmed.example")
+	hinted := RelayState{
+		Descriptor: mustPolicyRelayDescriptor(t, "relay-hinted", "https://relay-hinted.example"),
+		LastSeenAt: time.Now().UTC(),
+	}
+	bannedConfirmed := confirmedPolicyRelayState(t, "relay-banned", "https://relay-banned.example")
+	bannedConfirmed.Banned = true
+
+	selected := policy.SelectConfirmed([]RelayState{
+		hinted,
+		confirmed,
+		bannedConfirmed,
+	})
+
+	if len(selected) != 1 {
+		t.Fatalf("len(selected) = %d, want 1", len(selected))
+	}
+	if got := selected[0].Descriptor.APIHTTPSAddr; got != confirmed.Descriptor.APIHTTPSAddr {
+		t.Fatalf("selected[0] = %q, want confirmed relay %q", got, confirmed.Descriptor.APIHTTPSAddr)
+	}
+}
+
 func TestSelectPriorityColdStartSelectsEligibleRelay(t *testing.T) {
 	policy := DefaultRelayPolicy{}
 	relayA := "https://relay-a.example"
@@ -104,7 +192,30 @@ func TestSelectPriorityColdStartSelectsEligibleRelay(t *testing.T) {
 	}
 }
 
-func TestSelectPriorityKeepsCurrentHealthyRelayOverNewConfirmedRelay(t *testing.T) {
+func TestSelectPriorityPrefersConfirmedRelayOverHintedRelay(t *testing.T) {
+	policy := DefaultRelayPolicy{}
+	confirmedRelay := confirmedPolicyRelayState(t, "relay-confirmed", "https://relay-confirmed.example")
+	hintedRelay := RelayState{
+		Descriptor: mustPolicyRelayDescriptor(t, "relay-hinted", "https://relay-hinted.example"),
+		LastSeenAt: time.Now().UTC(),
+	}
+
+	selected := policy.SelectPriority([]RelayState{
+		hintedRelay,
+		confirmedRelay,
+	}, ClientState{
+		MaxActiveRelays: 1,
+	})
+
+	if len(selected) != 1 {
+		t.Fatalf("len(selected) = %d, want 1", len(selected))
+	}
+	if got := selected[0]; got != confirmedRelay.Descriptor.APIHTTPSAddr {
+		t.Fatalf("selected[0] = %q, want confirmed relay %q", got, confirmedRelay.Descriptor.APIHTTPSAddr)
+	}
+}
+
+func TestSelectPriorityKeepsCurrentRelayOverNewConfirmedRelay(t *testing.T) {
 	policy := DefaultRelayPolicy{}
 	currentRelay := "https://relay-current.example"
 	newRelay := "https://relay-new.example"
@@ -121,7 +232,7 @@ func TestSelectPriorityKeepsCurrentHealthyRelayOverNewConfirmedRelay(t *testing.
 		t.Fatalf("len(selected) = %d, want 1", len(selected))
 	}
 	if got := selected[0]; got != currentRelay {
-		t.Fatalf("selected[0] = %q, want current healthy relay %q kept", got, currentRelay)
+		t.Fatalf("selected[0] = %q, want current relay %q kept", got, currentRelay)
 	}
 }
 
@@ -145,25 +256,75 @@ func TestSelectPriorityPushesHighRTTRelayBehindNormalRelay(t *testing.T) {
 	}
 }
 
-func TestSelectPriorityReplacesCurrentDeadRelay(t *testing.T) {
+func TestOnConfirmedMarksRelayConfirmed(t *testing.T) {
 	policy := DefaultRelayPolicy{}
-	currentRelay := bootstrapPolicyRelayState("https://relay-current.example")
-	currentRelay.Reachable = false
-	currentRelay.consecutiveFailures = 1
-
-	replacementRelay := confirmedPolicyRelayState(t, "relay-new", "https://relay-new.example")
-	selected := policy.SelectPriority([]RelayState{
-		currentRelay,
-		replacementRelay,
-	}, ClientState{
-		ActiveRelayURLs: []string{currentRelay.Descriptor.APIHTTPSAddr},
-		MaxActiveRelays: 1,
-	})
-
-	if len(selected) != 1 {
-		t.Fatalf("len(selected) = %d, want 1", len(selected))
+	nextDirectRefreshAt := time.Now().UTC().Add(time.Minute)
+	state := RelayState{
+		Descriptor:          mustPolicyRelayDescriptor(t, "relay-a", "https://relay-a.example"),
+		LastSeenAt:          time.Now().UTC(),
+		consecutiveFailures: defaultRecoveryFailures,
+		nextDirectRefreshAt: nextDirectRefreshAt,
 	}
-	if got := selected[0]; got != replacementRelay.Descriptor.APIHTTPSAddr {
-		t.Fatalf("selected[0] = %q, want replacement relay %q", got, replacementRelay.Descriptor.APIHTTPSAddr)
+
+	state = policy.OnConfirmed(state)
+
+	if !state.Confirmed {
+		t.Fatal("relay should become confirmed")
+	}
+	if state.consecutiveFailures != defaultRecoveryFailures {
+		t.Fatalf("consecutiveFailures = %d, want %d", state.consecutiveFailures, defaultRecoveryFailures)
+	}
+	if !state.nextDirectRefreshAt.Equal(nextDirectRefreshAt) {
+		t.Fatalf("nextDirectRefreshAt = %v, want %v", state.nextDirectRefreshAt, nextDirectRefreshAt)
+	}
+}
+
+func TestOnUnconfirmedClearsRelayConfirmation(t *testing.T) {
+	policy := DefaultRelayPolicy{}
+	state := confirmedPolicyRelayState(t, "relay-a", "https://relay-a.example")
+
+	state = policy.OnUnconfirmed(state)
+
+	if state.Confirmed {
+		t.Fatal("relay should become unconfirmed")
+	}
+}
+
+func TestOnFailureSchedulesDirectRecoveryRetry(t *testing.T) {
+	policy := DefaultRelayPolicy{}
+	state := confirmedPolicyRelayState(t, "relay-a", "https://relay-a.example")
+	startedAt := time.Now().UTC()
+
+	var backedOff bool
+	var reason string
+	for range defaultRecoveryFailures {
+		state, backedOff, reason = policy.OnFailure(state, errors.New("boom"), defaultRecoveryFailures)
+	}
+
+	if !backedOff {
+		t.Fatal("expected relay to back off after recovery failure budget")
+	}
+	if reason != "recovery" {
+		t.Fatalf("backoff reason = %q, want recovery", reason)
+	}
+	if !state.nextDirectRefreshAt.After(startedAt) {
+		t.Fatalf("nextDirectRefreshAt = %v, want a future retry time", state.nextDirectRefreshAt)
+	}
+}
+
+func TestOnFailureSchedulesRetryForHintedRelay(t *testing.T) {
+	policy := DefaultRelayPolicy{}
+	state := RelayState{
+		Descriptor: mustPolicyRelayDescriptor(t, "relay-hinted", "https://relay-hinted.example"),
+		LastSeenAt: time.Now().UTC(),
+	}
+	startedAt := time.Now().UTC()
+
+	for range defaultRecoveryFailures {
+		state, _, _ = policy.OnFailure(state, errors.New("boom"), defaultRecoveryFailures)
+	}
+
+	if !state.nextDirectRefreshAt.After(startedAt) {
+		t.Fatalf("nextDirectRefreshAt = %v, want a future retry time", state.nextDirectRefreshAt)
 	}
 }

--- a/portal/discovery/refresher.go
+++ b/portal/discovery/refresher.go
@@ -19,7 +19,7 @@ import (
 const (
 	defaultRequestTimeout   = 15 * time.Second
 	DiscoveryPollInterval   = 30 * time.Second
-	defaultRecoveryFailures = 3
+	defaultRecoveryFailures = 5
 )
 
 type OverlayRuntime interface {
@@ -98,7 +98,19 @@ func (r *Refresher) refreshHTTPS(ctx context.Context, extraSourceHosts []string)
 
 	now := time.Now().UTC()
 	for _, state := range states {
-		if !state.discoverable(now) || (state.hasDescriptor() && !state.Descriptor.Discovery) {
+		if state.Banned {
+			continue
+		}
+		if !state.hasDescriptor() {
+			if !state.Bootstrap {
+				continue
+			}
+		} else if !state.Bootstrap {
+			if !state.nextDirectRefreshAt.IsZero() && state.nextDirectRefreshAt.After(now) {
+				continue
+			}
+		}
+		if state.hasDescriptor() && !state.Descriptor.Discovery {
 			continue
 		}
 
@@ -226,18 +238,18 @@ func (r *Refresher) refreshOverlay(ctx context.Context) error {
 }
 
 func (r *Refresher) logDiscoveryFailure(targetRelayURL, sourceURL string, recoveryFailures int, err error) {
-	expired, expireReason, consecutiveFailures := r.relaySet.RecordRelayFailure(targetRelayURL, err, recoveryFailures)
-	if !expired {
+	backedOff, backoffReason, consecutiveFailures := r.relaySet.RecordRelayFailure(targetRelayURL, err, recoveryFailures)
+	if !backedOff {
 		return
 	}
 
 	event := log.Warn().
 		Err(err).
 		Str("relay", sourceURL).
-		Bool("expired", true).
-		Str("reason", expireReason)
+		Bool("backed_off", true).
+		Str("reason", backoffReason)
 	if consecutiveFailures > 0 {
 		event = event.Int("consecutive_failures", consecutiveFailures)
 	}
-	event.Msg("discovery source expired")
+	event.Msg("discovery source retry delayed")
 }

--- a/portal/discovery/refresher_test.go
+++ b/portal/discovery/refresher_test.go
@@ -1,0 +1,154 @@
+package discovery
+
+import (
+	"context"
+	"encoding/pem"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/gosuda/portal-tunnel/v2/types"
+	"github.com/gosuda/portal-tunnel/v2/utils"
+)
+
+func newDiscoveryTestServer(t *testing.T, handler http.HandlerFunc) (*httptest.Server, []byte) {
+	t.Helper()
+
+	server := httptest.NewTLSServer(handler)
+	rootCAPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: server.Certificate().Raw})
+	if rootCAPEM == nil {
+		server.Close()
+		t.Fatal("failed to encode test certificate")
+	}
+	return server, rootCAPEM
+}
+
+func TestRefresherRefreshesExpiredBootstrapRelay(t *testing.T) {
+	now := time.Now().UTC()
+	var relayURL string
+	server, rootCAPEM := newDiscoveryTestServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		utils.WriteAPIData(w, http.StatusOK, types.DiscoveryResponse{
+			ProtocolVersion: types.DiscoveryVersion,
+			GeneratedAt:     now,
+			Relays: []types.RelayDescriptor{
+				mustPolicyRelayDescriptor(t, "relay-bootstrap", relayURL),
+			},
+		})
+	}))
+	defer server.Close()
+	relayURL = server.URL
+
+	set, err := NewRelaySet([]string{relayURL})
+	if err != nil {
+		t.Fatalf("NewRelaySet() error = %v", err)
+	}
+
+	set.mu.Lock()
+	state := set.relays[relayURL]
+	state.Descriptor = mustPolicyRelayDescriptor(t, "relay-bootstrap", relayURL)
+	state.Descriptor.ExpiresAt = now.Add(-time.Second)
+	state.LastSeenAt = now.Add(-time.Minute)
+	set.relays[relayURL] = state
+	set.mu.Unlock()
+
+	refresher, err := NewRefresher(set, rootCAPEM, nil, "")
+	if err != nil {
+		t.Fatalf("NewRefresher() error = %v", err)
+	}
+	if err := refresher.Refresh(context.Background()); err != nil {
+		t.Fatalf("Refresh() error = %v", err)
+	}
+
+	set.mu.RLock()
+	refreshed := set.relays[relayURL]
+	set.mu.RUnlock()
+	if refreshed.Confirmed {
+		t.Fatal("direct discovery refresh should not mark relay locally confirmed")
+	}
+	if !refreshed.Descriptor.ExpiresAt.After(now) {
+		t.Fatalf("refreshed descriptor expiry = %v, want a fresh descriptor", refreshed.Descriptor.ExpiresAt)
+	}
+}
+
+func TestRefresherRefreshesExpiredCollectedRelay(t *testing.T) {
+	now := time.Now().UTC()
+	var relayURL string
+	server, rootCAPEM := newDiscoveryTestServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		utils.WriteAPIData(w, http.StatusOK, types.DiscoveryResponse{
+			ProtocolVersion: types.DiscoveryVersion,
+			GeneratedAt:     now,
+			Relays: []types.RelayDescriptor{
+				mustPolicyRelayDescriptor(t, "relay-known", relayURL),
+			},
+		})
+	}))
+	defer server.Close()
+	relayURL = server.URL
+
+	set, err := NewRelaySet(nil)
+	if err != nil {
+		t.Fatalf("NewRelaySet() error = %v", err)
+	}
+
+	set.mu.Lock()
+	state := confirmedPolicyRelayState(t, "relay-known", relayURL)
+	state.Descriptor.ExpiresAt = now.Add(-time.Second)
+	state.LastSeenAt = now.Add(-time.Minute)
+	set.relays[relayURL] = state
+	set.mu.Unlock()
+
+	refresher, err := NewRefresher(set, rootCAPEM, nil, "")
+	if err != nil {
+		t.Fatalf("NewRefresher() error = %v", err)
+	}
+	if err := refresher.Refresh(context.Background()); err != nil {
+		t.Fatalf("Refresh() error = %v", err)
+	}
+
+	set.mu.RLock()
+	refreshed := set.relays[relayURL]
+	set.mu.RUnlock()
+	if !refreshed.Descriptor.ExpiresAt.After(now) {
+		t.Fatalf("refreshed descriptor expiry = %v, want a fresh descriptor", refreshed.Descriptor.ExpiresAt)
+	}
+}
+
+func TestRefresherSkipsDirectRetryUntilBackoffExpires(t *testing.T) {
+	now := time.Now().UTC()
+	var requests atomic.Int32
+	server, rootCAPEM := newDiscoveryTestServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests.Add(1)
+		utils.WriteAPIData(w, http.StatusOK, types.DiscoveryResponse{
+			ProtocolVersion: types.DiscoveryVersion,
+			GeneratedAt:     now,
+			Relays: []types.RelayDescriptor{
+				mustPolicyRelayDescriptor(t, "relay-known", r.Host),
+			},
+		})
+	}))
+	defer server.Close()
+
+	set, err := NewRelaySet(nil)
+	if err != nil {
+		t.Fatalf("NewRelaySet() error = %v", err)
+	}
+
+	set.mu.Lock()
+	state := confirmedPolicyRelayState(t, "relay-known", server.URL)
+	state.nextDirectRefreshAt = now.Add(time.Minute)
+	set.relays[server.URL] = state
+	set.mu.Unlock()
+
+	refresher, err := NewRefresher(set, rootCAPEM, nil, "")
+	if err != nil {
+		t.Fatalf("NewRefresher() error = %v", err)
+	}
+	if err := refresher.Refresh(context.Background()); err != nil {
+		t.Fatalf("Refresh() error = %v", err)
+	}
+	if got := requests.Load(); got != 0 {
+		t.Fatalf("direct refresh requests = %d, want 0 before backoff expires", got)
+	}
+}

--- a/portal/discovery/relayset.go
+++ b/portal/discovery/relayset.go
@@ -15,7 +15,7 @@ import (
 
 // RelaySet owns the shared relay discovery view: configured bootstrap relay URLs,
 // the latest validated descriptor seen for each relay, and local runtime state
-// such as ban/reachability/failure tracking and observed discovery RTT.
+// such as ban/failure tracking and observed discovery RTT.
 type RelaySet struct {
 	mu     sync.RWMutex
 	relays map[string]RelayState
@@ -74,11 +74,18 @@ func (s *RelaySet) SetBootstrapRelayURLs(inputs []string) error {
 	return nil
 }
 
-func (s *RelaySet) ActiveRelays() []RelayState {
+func (s *RelaySet) AggregateRelays() []RelayState {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
-	return s.policy.SelectActive(s.relayStatesLocked())
+	return s.policy.SelectAggregate(s.relayStatesLocked())
+}
+
+func (s *RelaySet) ConfirmedRelays() []RelayState {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	return s.policy.SelectConfirmed(s.relayStatesLocked())
 }
 
 func (s *RelaySet) PriorityRelays(clientState ClientState) []string {
@@ -96,7 +103,7 @@ func (s *RelaySet) OverlayPeerStates() []RelayState {
 	now := time.Now().UTC()
 	out := make([]RelayState, 0, len(states))
 	for _, state := range states {
-		if !state.discoverable(now) || !state.Descriptor.SupportsOverlayPeer {
+		if state.Banned || !state.hasDescriptor() || !state.Descriptor.ExpiresAt.After(now) || !state.Descriptor.SupportsOverlayPeer {
 			continue
 		}
 		if state.Descriptor.WireGuardPublicKey == "" ||
@@ -120,10 +127,21 @@ func (s *RelaySet) Descriptors() []types.RelayDescriptor {
 	now := time.Now().UTC()
 	out := make([]types.RelayDescriptor, 0, len(states))
 	for _, state := range states {
-		if !state.hasDescriptor() || !state.Descriptor.ExpiresAt.After(now) || !state.Descriptor.Discovery {
+		if state.Banned || !state.hasDescriptor() || !state.Descriptor.Discovery {
 			continue
 		}
-		out = append(out, state.Descriptor)
+		desc := state.Descriptor
+		if !desc.ExpiresAt.After(now) {
+			if state.LastSeenAt.IsZero() || !state.LastSeenAt.After(now.Add(-DiscoveryHintRetentionTTL)) {
+				continue
+			}
+
+			// Keep stale relay hints flowing through discovery so the mesh converges
+			// on a large shared relay set. Local listener confirmation and direct
+			// refresh retry state are tracked separately.
+			desc.ExpiresAt = now.Add(DiscoveryDescriptorTTL)
+		}
+		out = append(out, desc)
 	}
 	if len(out) == 0 {
 		return nil
@@ -191,32 +209,53 @@ func (s *RelaySet) BanRelayURL(relayURL string) {
 	s.relays[relayURL] = state
 }
 
+func (s *RelaySet) ConfirmRelayURL(relayURL string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	state, ok := s.relays[relayURL]
+	if !ok {
+		state = newRelayStateFromURL(relayURL)
+	}
+	state = s.policy.OnConfirmed(state)
+	s.relays[relayURL] = state
+}
+
+func (s *RelaySet) UnconfirmRelayURL(relayURL string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	state, ok := s.relays[relayURL]
+	if !ok {
+		return
+	}
+	state = s.policy.OnUnconfirmed(state)
+	s.relays[relayURL] = state
+}
+
 func (s *RelaySet) ApplyRelayDiscoveryResponse(targetURL string, resp types.DiscoveryResponse, now time.Time) (relaySetChanged bool, err error) {
 	if now.IsZero() {
 		now = time.Now().UTC()
 	} else {
 		now = now.UTC()
 	}
-
-	if resp.ProtocolVersion != types.DiscoveryVersion {
-		return false, fmt.Errorf("relay discovery protocol version mismatch: relay=%q client=%q", resp.ProtocolVersion, types.DiscoveryVersion)
-	}
+	protocolMismatch := resp.ProtocolVersion != types.DiscoveryVersion
 	authoritative := targetURL != ""
 
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
 	discoveredByURL := make(map[string]RelayState, len(resp.Relays))
-	discoveredOrder := make([]string, 0, len(resp.Relays))
+	discoveredOrder := make([]string, 0, len(resp.Relays)+1)
 	targetFound := false
-	for _, descriptor := range resp.Relays {
+	add := func(descriptor types.RelayDescriptor) {
 		relayState, err := newRelayState(descriptor, now)
 		if err != nil {
-			continue
+			return
 		}
 		relayURL := relayState.Descriptor.APIHTTPSAddr
 		if relayURL == "" {
-			continue
+			return
 		}
 		if authoritative && relayURL == targetURL {
 			targetFound = true
@@ -226,30 +265,29 @@ func (s *RelaySet) ApplyRelayDiscoveryResponse(targetURL string, resp types.Disc
 		}
 		discoveredByURL[relayURL] = relayState
 	}
-
-	if authoritative && !targetFound {
-		return false, errors.New("target relay descriptor missing from relays")
+	for _, descriptor := range resp.Relays {
+		add(descriptor)
 	}
+	missingTarget := authoritative && !targetFound
 
 	for _, relayURL := range discoveredOrder {
 		record := discoveredByURL[relayURL]
 		existingAtURL, hasExistingAtURL := s.relays[relayURL]
 		record.Bootstrap = record.Bootstrap || existingAtURL.Bootstrap
-		record.Reachable = record.Reachable || existingAtURL.Reachable
 		record.Confirmed = record.Confirmed || existingAtURL.Confirmed
 		record.Banned = record.Banned || existingAtURL.Banned
 		if record.consecutiveFailures < existingAtURL.consecutiveFailures {
 			record.consecutiveFailures = existingAtURL.consecutiveFailures
 		}
+		record.nextDirectRefreshAt = existingAtURL.nextDirectRefreshAt
 		if record.DiscoveryRTTAt.IsZero() || (!existingAtURL.DiscoveryRTTAt.IsZero() && existingAtURL.DiscoveryRTTAt.After(record.DiscoveryRTTAt)) {
 			record.DiscoveryRTT = existingAtURL.DiscoveryRTT
 			record.DiscoveryRTTAt = existingAtURL.DiscoveryRTTAt
 		}
 
-		if authoritative && relayURL == targetURL {
-			record = s.policy.OnConfirmed(record)
-		} else {
-			record = s.policy.OnHinted(record)
+		if !protocolMismatch && !missingTarget && authoritative && relayURL == targetURL {
+			record.consecutiveFailures = 0
+			record.nextDirectRefreshAt = time.Time{}
 		}
 
 		s.relays[relayURL] = record
@@ -257,6 +295,12 @@ func (s *RelaySet) ApplyRelayDiscoveryResponse(targetURL string, resp types.Disc
 		if !hasExistingAtURL || !reflect.DeepEqual(existingAtURL, record) {
 			relaySetChanged = true
 		}
+	}
+	if missingTarget {
+		return relaySetChanged, errors.New("target relay descriptor missing from relays")
+	}
+	if protocolMismatch && authoritative {
+		return relaySetChanged, fmt.Errorf("relay discovery protocol version mismatch: relay=%q client=%q", resp.ProtocolVersion, types.DiscoveryVersion)
 	}
 	return relaySetChanged, nil
 }
@@ -275,7 +319,7 @@ func (s *RelaySet) RecordDiscoveryRTT(relayURL string, rtt time.Duration, measur
 	s.relays[relayURL] = state
 }
 
-func (s *RelaySet) RecordRelayFailure(relayURL string, err error, recoveryFailures int) (expired bool, expireReason string, consecutiveFailures int) {
+func (s *RelaySet) RecordRelayFailure(relayURL string, err error, recoveryFailures int) (backedOff bool, backoffReason string, consecutiveFailures int) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -283,7 +327,7 @@ func (s *RelaySet) RecordRelayFailure(relayURL string, err error, recoveryFailur
 	if !ok {
 		return false, "", 0
 	}
-	state, expired, expireReason = s.policy.OnFailure(state, err, recoveryFailures)
+	state, backedOff, backoffReason = s.policy.OnFailure(state, err, recoveryFailures)
 	s.relays[relayURL] = state
-	return expired, expireReason, state.consecutiveFailures
+	return backedOff, backoffReason, state.consecutiveFailures
 }

--- a/portal/discovery/relayset_test.go
+++ b/portal/discovery/relayset_test.go
@@ -21,11 +21,262 @@ func TestApplyRelayDiscoveryResponsePreservesBootstrapFlag(t *testing.T) {
 		t.Fatalf("ApplyRelayDiscoveryResponse() error = %v", err)
 	}
 
-	states := set.ActiveRelays()
+	states := set.AggregateRelays()
 	if len(states) != 1 {
-		t.Fatalf("len(ActiveRelays()) = %d, want 1", len(states))
+		t.Fatalf("len(AggregateRelays()) = %d, want 1", len(states))
 	}
 	if !states[0].Bootstrap {
 		t.Fatal("bootstrap relay lost bootstrap flag after discovery update")
+	}
+}
+
+func TestDescriptorsKeepsStaleRelayHintWithinRetentionWindow(t *testing.T) {
+	set, err := NewRelaySet(nil)
+	if err != nil {
+		t.Fatalf("NewRelaySet() error = %v", err)
+	}
+
+	now := time.Now().UTC()
+	relayURL := "https://relay-stale.example"
+	state := confirmedPolicyRelayState(t, "relay-stale", relayURL)
+	state.Descriptor.ExpiresAt = now.Add(-time.Minute)
+	state.LastSeenAt = now.Add(-6 * time.Hour)
+	state.Descriptor.SupportsUDP = true
+	state.Descriptor.SupportsTCP = true
+	state.Descriptor.SupportsOverlayPeer = true
+	state.Descriptor.IngressTLSAddr = "relay-stale.example:443"
+	state.Descriptor.WireGuardPublicKey = "pub"
+	state.Descriptor.WireGuardEndpoint = "relay-stale.example:51820"
+	state.Descriptor.OverlayIPv4 = "10.0.0.1"
+	state.Descriptor.OverlayCIDRs = []string{"10.0.0.0/24"}
+	state.Descriptor.Load = 1
+	state.Descriptor.LoadScore = 2
+
+	set.mu.Lock()
+	set.relays[relayURL] = state
+	set.mu.Unlock()
+
+	descriptors := set.Descriptors()
+	if len(descriptors) != 1 {
+		t.Fatalf("len(Descriptors()) = %d, want 1", len(descriptors))
+	}
+	got := descriptors[0]
+	if got.APIHTTPSAddr != relayURL {
+		t.Fatalf("descriptor api_https_addr = %q, want %q", got.APIHTTPSAddr, relayURL)
+	}
+	if !got.ExpiresAt.After(now) {
+		t.Fatalf("descriptor expires_at = %v, want future expiry", got.ExpiresAt)
+	}
+	if !got.SupportsUDP || !got.SupportsTCP || !got.SupportsOverlayPeer {
+		t.Fatal("stale advertised descriptor should preserve last known capability claims")
+	}
+	if got.IngressTLSAddr == "" || got.WireGuardPublicKey == "" || got.WireGuardEndpoint == "" || got.OverlayIPv4 == "" || len(got.OverlayCIDRs) == 0 {
+		t.Fatal("stale advertised descriptor should preserve last known routing fields")
+	}
+	if got.Load != 1 || got.LoadScore != 2 {
+		t.Fatal("stale advertised descriptor should preserve last known load signals")
+	}
+}
+
+func TestDescriptorsDropsRelayAfterHintRetentionWindow(t *testing.T) {
+	set, err := NewRelaySet(nil)
+	if err != nil {
+		t.Fatalf("NewRelaySet() error = %v", err)
+	}
+
+	now := time.Now().UTC()
+	relayURL := "https://relay-old.example"
+	state := confirmedPolicyRelayState(t, "relay-old", relayURL)
+	state.Descriptor.ExpiresAt = now.Add(-time.Minute)
+	state.LastSeenAt = now.Add(-DiscoveryHintRetentionTTL).Add(-time.Minute)
+
+	set.mu.Lock()
+	set.relays[relayURL] = state
+	set.mu.Unlock()
+
+	descriptors := set.Descriptors()
+	if len(descriptors) != 0 {
+		t.Fatalf("len(Descriptors()) = %d, want 0", len(descriptors))
+	}
+}
+
+func TestApplyRelayDiscoveryResponseCollectsRelaysDespiteProtocolMismatch(t *testing.T) {
+	set, err := NewRelaySet(nil)
+	if err != nil {
+		t.Fatalf("NewRelaySet() error = %v", err)
+	}
+
+	desc := mustPolicyRelayDescriptor(t, "relay-mismatch", "https://relay-mismatch.example")
+	changed, err := set.ApplyRelayDiscoveryResponse("", types.DiscoveryResponse{
+		ProtocolVersion: "5",
+		Relays:          []types.RelayDescriptor{desc},
+	}, time.Now().UTC())
+	if err != nil {
+		t.Fatalf("ApplyRelayDiscoveryResponse() error = %v", err)
+	}
+	if !changed {
+		t.Fatal("expected protocol-mismatched discovery response to change relay set")
+	}
+
+	states := set.AggregateRelays()
+	if len(states) != 1 {
+		t.Fatalf("len(AggregateRelays()) = %d, want 1", len(states))
+	}
+	if got := states[0].Descriptor.APIHTTPSAddr; got != desc.APIHTTPSAddr {
+		t.Fatalf("states[0] = %q, want %q", got, desc.APIHTTPSAddr)
+	}
+	if states[0].Confirmed {
+		t.Fatal("hinted relay should not become locally confirmed from aggregation")
+	}
+}
+
+func TestApplyRelayDiscoveryResponseCollectsHintsWhenTargetDescriptorIsMissing(t *testing.T) {
+	set, err := NewRelaySet(nil)
+	if err != nil {
+		t.Fatalf("NewRelaySet() error = %v", err)
+	}
+
+	hinted := mustPolicyRelayDescriptor(t, "relay-hinted", "https://relay-hinted.example")
+	changed, err := set.ApplyRelayDiscoveryResponse("https://relay-source.example", types.DiscoveryResponse{
+		ProtocolVersion: "5",
+		Relays:          []types.RelayDescriptor{hinted},
+	}, time.Now().UTC())
+	if err == nil {
+		t.Fatal("expected missing target descriptor error")
+	}
+	if !changed {
+		t.Fatal("expected hinted relay to still be collected")
+	}
+
+	states := set.AggregateRelays()
+	if len(states) != 1 {
+		t.Fatalf("len(AggregateRelays()) = %d, want 1", len(states))
+	}
+	if got := states[0].Descriptor.APIHTTPSAddr; got != hinted.APIHTTPSAddr {
+		t.Fatalf("states[0] = %q, want %q", got, hinted.APIHTTPSAddr)
+	}
+	if states[0].Confirmed {
+		t.Fatal("hinted relay should not become locally confirmed when target descriptor is missing")
+	}
+}
+
+func TestApplyRelayDiscoveryResponseClearsDirectRetryOnAuthoritativeSuccess(t *testing.T) {
+	set, err := NewRelaySet(nil)
+	if err != nil {
+		t.Fatalf("NewRelaySet() error = %v", err)
+	}
+
+	relayURL := "https://relay-source.example"
+	desc := mustPolicyRelayDescriptor(t, "relay-source", relayURL)
+	set.mu.Lock()
+	state := RelayState{
+		Descriptor:          desc,
+		LastSeenAt:          time.Now().UTC(),
+		consecutiveFailures: defaultRecoveryFailures,
+		nextDirectRefreshAt: time.Now().UTC().Add(time.Minute),
+	}
+	set.relays[relayURL] = state
+	set.mu.Unlock()
+
+	if _, err := set.ApplyRelayDiscoveryResponse(relayURL, types.DiscoveryResponse{
+		ProtocolVersion: types.DiscoveryVersion,
+		Relays:          []types.RelayDescriptor{desc},
+	}, time.Now().UTC()); err != nil {
+		t.Fatalf("ApplyRelayDiscoveryResponse() error = %v", err)
+	}
+
+	set.mu.RLock()
+	refreshed := set.relays[relayURL]
+	set.mu.RUnlock()
+	if refreshed.consecutiveFailures != 0 {
+		t.Fatalf("consecutiveFailures = %d, want 0", refreshed.consecutiveFailures)
+	}
+	if !refreshed.nextDirectRefreshAt.IsZero() {
+		t.Fatalf("nextDirectRefreshAt = %v, want zero time", refreshed.nextDirectRefreshAt)
+	}
+}
+
+func TestApplyRelayDiscoveryResponsePreservesDirectRetryOnHint(t *testing.T) {
+	set, err := NewRelaySet(nil)
+	if err != nil {
+		t.Fatalf("NewRelaySet() error = %v", err)
+	}
+
+	relayURL := "https://relay-hinted.example"
+	desc := mustPolicyRelayDescriptor(t, "relay-hinted", relayURL)
+	nextDirectRefreshAt := time.Now().UTC().Add(time.Minute)
+	set.mu.Lock()
+	state := RelayState{
+		Descriptor:          desc,
+		LastSeenAt:          time.Now().UTC(),
+		nextDirectRefreshAt: nextDirectRefreshAt,
+	}
+	set.relays[relayURL] = state
+	set.mu.Unlock()
+
+	if _, err := set.ApplyRelayDiscoveryResponse("", types.DiscoveryResponse{
+		ProtocolVersion: types.DiscoveryVersion,
+		Relays:          []types.RelayDescriptor{desc},
+	}, time.Now().UTC()); err != nil {
+		t.Fatalf("ApplyRelayDiscoveryResponse() error = %v", err)
+	}
+
+	set.mu.RLock()
+	refreshed := set.relays[relayURL]
+	set.mu.RUnlock()
+	if !refreshed.nextDirectRefreshAt.Equal(nextDirectRefreshAt) {
+		t.Fatalf("nextDirectRefreshAt = %v, want %v", refreshed.nextDirectRefreshAt, nextDirectRefreshAt)
+	}
+}
+
+func TestConfirmRelayURLMarksRelayConfirmedWithoutChangingAggregateDescriptor(t *testing.T) {
+	set, err := NewRelaySet(nil)
+	if err != nil {
+		t.Fatalf("NewRelaySet() error = %v", err)
+	}
+
+	relayURL := "https://relay-confirmed.example"
+	state := RelayState{
+		Descriptor: mustPolicyRelayDescriptor(t, "relay-confirmed", relayURL),
+		LastSeenAt: time.Now().UTC(),
+	}
+
+	set.mu.Lock()
+	set.relays[relayURL] = state
+	set.mu.Unlock()
+
+	set.ConfirmRelayURL(relayURL)
+
+	set.mu.RLock()
+	confirmed := set.relays[relayURL]
+	set.mu.RUnlock()
+	if !confirmed.Confirmed {
+		t.Fatal("relay should become locally confirmed after listener success")
+	}
+	if confirmed.Descriptor.APIHTTPSAddr != relayURL {
+		t.Fatalf("descriptor api_https_addr = %q, want %q", confirmed.Descriptor.APIHTTPSAddr, relayURL)
+	}
+}
+
+func TestUnconfirmRelayURLClearsLocalConfirmationOnly(t *testing.T) {
+	set, err := NewRelaySet(nil)
+	if err != nil {
+		t.Fatalf("NewRelaySet() error = %v", err)
+	}
+
+	relayURL := "https://relay-confirmed.example"
+	state := confirmedPolicyRelayState(t, "relay-confirmed", relayURL)
+
+	set.mu.Lock()
+	set.relays[relayURL] = state
+	set.mu.Unlock()
+
+	set.UnconfirmRelayURL(relayURL)
+
+	set.mu.RLock()
+	unconfirmed := set.relays[relayURL]
+	set.mu.RUnlock()
+	if unconfirmed.Confirmed {
+		t.Fatal("relay should lose local confirmation after listener failure")
 	}
 }

--- a/portal/discovery/relaystate.go
+++ b/portal/discovery/relaystate.go
@@ -8,17 +8,25 @@ import (
 	"github.com/gosuda/portal-tunnel/v2/utils"
 )
 
+const (
+	DiscoveryDescriptorTTL       = 5 * time.Minute
+	DiscoveryHintRetentionTTL    = 30 * 24 * time.Hour
+	defaultDirectRecoveryBackoff = 1 * time.Minute
+	maxDirectRecoveryBackoff     = 5 * time.Minute
+)
+
 type RelayState struct {
-	Descriptor     types.RelayDescriptor
-	Bootstrap      bool
-	Reachable      bool
-	Confirmed      bool
-	Banned         bool
-	LastSeenAt     time.Time
+	Descriptor types.RelayDescriptor
+	Bootstrap  bool
+	Confirmed  bool
+	Banned     bool
+	LastSeenAt time.Time
+
 	DiscoveryRTT   time.Duration
 	DiscoveryRTTAt time.Time
 
 	consecutiveFailures int
+	nextDirectRefreshAt time.Time
 }
 
 type ClientState struct {
@@ -65,20 +73,4 @@ func newRelayStateFromURL(relayURL string) RelayState {
 
 func (state RelayState) hasDescriptor() bool {
 	return !state.LastSeenAt.IsZero()
-}
-
-func (state RelayState) discoverable(now time.Time) bool {
-	if state.Banned {
-		return false
-	}
-	if !state.hasDescriptor() {
-		return state.Bootstrap
-	}
-	if !state.Bootstrap && !state.Reachable {
-		return false
-	}
-	if !state.Descriptor.ExpiresAt.After(now) {
-		return false
-	}
-	return true
 }

--- a/sdk/expose_test.go
+++ b/sdk/expose_test.go
@@ -71,42 +71,6 @@ func TestExposureReconcileRemovesBannedRelayFromActiveSet(t *testing.T) {
 	}
 }
 
-func TestExposureReconcileSkipsBannedRelay(t *testing.T) {
-	const (
-		relayA = "https://relay-a.example"
-		relayB = "https://relay-b.example"
-	)
-
-	exposure := &Exposure{
-		relaySet:       mustRelaySet(t),
-		relayListeners: make(map[string]*Listener, 1),
-	}
-	exposure.relaySet.BanRelayURL(relayB)
-	exposure.relayListeners = map[string]*Listener{
-		relayA: {},
-	}
-
-	if err := exposure.relaySet.SetBootstrapRelayURLs([]string{relayA, relayB}); err != nil {
-		t.Fatalf("SetBootstrapRelayURLs() error = %v", err)
-	}
-	if err := exposure.reconcileRelayListeners(false); err != nil {
-		t.Fatalf("reconcileRelayListeners() error = %v", err)
-	}
-	if got := exposure.ActiveRelayURLs(); len(got) != 1 || got[0] != relayA {
-		t.Fatalf("ActiveRelayURLs() = %v, want [%q]", got, relayA)
-	}
-	exposure.listenerMu.RLock()
-	_, relayAExists := exposure.relayListeners[relayA]
-	_, relayBExists := exposure.relayListeners[relayB]
-	exposure.listenerMu.RUnlock()
-	if !relayAExists {
-		t.Fatal("active relay listener missing from exposure.listeners")
-	}
-	if relayBExists {
-		t.Fatal("banned relay listener should not be added to exposure.listeners")
-	}
-}
-
 func TestExposureReconcileRemovesStaleListener(t *testing.T) {
 	const (
 		relayA = "https://relay-a.example"

--- a/sdk/listener.go
+++ b/sdk/listener.go
@@ -148,6 +148,7 @@ func (l *Listener) runStartup(ctx context.Context) {
 				errors.Is(err, &types.APIRequestError{Code: types.APIErrorCodeHostnameConflict}) ||
 				errors.Is(err, &types.APIRequestError{Code: types.APIErrorCodeIPBanned}) {
 				if l.relaySet != nil && l.api != nil && l.api.baseURL != nil {
+					l.relaySet.UnconfirmRelayURL(l.api.baseURL.String())
 					l.relaySet.RecordRelayFailure(l.api.baseURL.String(), err, 1)
 				}
 				log.Error().
@@ -656,6 +657,9 @@ func (l *Listener) registerAndConfigure(ctx context.Context) error {
 	if datagram != nil {
 		datagram.Clear("lease updated")
 	}
+	if l.relaySet != nil && l.api != nil && l.api.baseURL != nil {
+		l.relaySet.ConfirmRelayURL(l.api.baseURL.String())
+	}
 	l.registerOnce.Do(func() { close(l.registered) })
 	return nil
 }
@@ -673,6 +677,7 @@ func (l *Listener) retryOrClose(ctx context.Context, operation string, err error
 
 	if l.retryCount > 0 && retries > l.retryCount {
 		if l.relaySet != nil && l.api != nil && l.api.baseURL != nil {
+			l.relaySet.UnconfirmRelayURL(l.api.baseURL.String())
 			l.relaySet.RecordRelayFailure(l.api.baseURL.String(), err, 1)
 		}
 		if operation != "lease renewal" {
@@ -729,6 +734,7 @@ func (l *Listener) closed() bool {
 
 func (l *Listener) ban() {
 	if l.relaySet != nil && l.api != nil && l.api.baseURL != nil {
+		l.relaySet.UnconfirmRelayURL(l.api.baseURL.String())
 		l.relaySet.BanRelayURL(l.api.baseURL.String())
 	}
 	_ = l.Close()

--- a/sdk/mitm_test.go
+++ b/sdk/mitm_test.go
@@ -228,7 +228,7 @@ func TestMITMProbeDetectionBansListener(t *testing.T) {
 		Reason:   types.MITMProbeReasonExporterMismatch,
 	}, nil)
 
-	for _, state := range listener.relaySet.ActiveRelays() {
+	for _, state := range listener.relaySet.AggregateRelays() {
 		if state.Descriptor.APIHTTPSAddr == relayURL.String() {
 			t.Fatal("relay still active after mitm detection")
 		}
@@ -261,7 +261,7 @@ func TestMITMProbeDetectionWarnsWithoutBanningListener(t *testing.T) {
 	}, nil)
 
 	activeRelayURLs := make([]string, 0)
-	for _, state := range listener.relaySet.ActiveRelays() {
+	for _, state := range listener.relaySet.AggregateRelays() {
 		activeRelayURLs = append(activeRelayURLs, state.Descriptor.APIHTTPSAddr)
 	}
 	if len(activeRelayURLs) != 1 || activeRelayURLs[0] != relayURL.String() {


### PR DESCRIPTION
- Updated the relay discovery logic to improve handling of expired and banned relays.
- Enhanced the `RelaySet` structure to include methods for confirming and unconfirming relays.
- Modified the `Refresher` to skip banned relays during the refresh process.
- Adjusted the relay state management to ensure that stale hints are preserved within a retention window.
- Removed redundant checks and improved the clarity of the relay selection logic.