### PR TITLE
feat(cli): add version subcommand

### DIFF
--- a/cmd/portal-tunnel/main.go
+++ b/cmd/portal-tunnel/main.go
@@ -22,6 +22,10 @@ func main() {
 	if err := utils.RunCommands(os.Args[1:], os.Stdout, os.Stderr, printRootUsage, map[string]utils.CommandFunc{
 		"expose": runExposeCommand,
 		"list":   runListCommand,
+		"version": func(args []string) error {
+			fmt.Fprintln(os.Stdout, types.ReleaseVersion)
+			return nil
+		},
 		"help": utils.MakeHelpCommand(printRootUsage, []utils.HelpTopic{
 			{Name: "expose", Usage: printExposeUsage},
 			{Name: "list", Usage: printListUsage},

--- a/cmd/portal-tunnel/main.go
+++ b/cmd/portal-tunnel/main.go
@@ -187,6 +187,7 @@ func printRootUsage(w io.Writer) {
 			"portal expose [flags] <target>",
 			"portal expose [flags] --http-route PATH=UPSTREAM [--http-route PATH=UPSTREAM]",
 			"portal list [flags]",
+			"portal version",
 		},
 		[]string{
 			"portal expose 3000",
@@ -194,6 +195,7 @@ func printRootUsage(w io.Writer) {
 			"portal expose --http-route /api=http://127.0.0.1:3001 --http-route /=http://127.0.0.1:5173 --name my-app",
 			"portal expose 3000 --udp --udp-addr 127.0.0.1:5353",
 			"portal list",
+			"portal version",
 		},
 	)
 }


### PR DESCRIPTION
## Summary
- Add `portal version` subcommand that prints `types.ReleaseVersion` to stdout
- Reuses the existing `ReleaseVersion` constant so CLI version stays in sync with releases

## Test plan
- [x] `go build ./cmd/portal-tunnel/` compiles successfully
- [x] `./portal-tunnel version` outputs `v2.1.5`

🤖 Generated with [Claude Code](https://claude.com/claude-code)