### PR TITLE
feat(cli): show relay version in portal list output

### DIFF
--- a/cmd/portal-tunnel/main.go
+++ b/cmd/portal-tunnel/main.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"sync"
 	"time"
 
 	"github.com/rs/zerolog"
@@ -175,8 +176,23 @@ func runListCommand(args []string) error {
 		return errors.New("no relay URLs configured")
 	}
 
-	for _, relayURL := range relayURLs {
-		fmt.Println(relayURL)
+	versions := make([]string, len(relayURLs))
+	var wg sync.WaitGroup
+	wg.Add(len(relayURLs))
+	for i, u := range relayURLs {
+		go func(idx int, url string) {
+			defer wg.Done()
+			versions[idx] = utils.FetchRelayVersion(ctx, url)
+		}(i, u)
+	}
+	wg.Wait()
+
+	for i, relayURL := range relayURLs {
+		ver := versions[i]
+		if ver == "" {
+			ver = "unknown"
+		}
+		fmt.Printf("%s\t%s\n", relayURL, ver)
 	}
 	return nil
 }

--- a/utils/network.go
+++ b/utils/network.go
@@ -122,6 +122,25 @@ func SanitizeReportedIP(raw string) string {
 	return candidate
 }
 
+// FetchRelayVersion calls GET /sdk/domain on a relay and returns its release version.
+// Returns an empty string on any error (timeout, unreachable, bad response).
+func FetchRelayVersion(ctx context.Context, relayURL string) string {
+	client := &http.Client{Timeout: 3 * time.Second}
+	resp, err := httpDo(ctx, client, http.MethodGet, relayURL+types.PathSDKDomain, nil, nil)
+	if err != nil {
+		return ""
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return ""
+	}
+	var envelope types.APIEnvelope[types.DomainResponse]
+	if err := json.NewDecoder(resp.Body).Decode(&envelope); err != nil || !envelope.OK {
+		return ""
+	}
+	return envelope.Data.ReleaseVersion
+}
+
 func ResolvePortalRelayURLs(ctx context.Context, explicit []string, includeDefaults bool) ([]string, error) {
 	explicit, err := NormalizeRelayURLs(explicit...)
 	if err != nil {


### PR DESCRIPTION
## Summary
- `portal list` now shows each relay's software version alongside its URL
- Calls `GET /sdk/domain` on each relay in parallel (3s per-relay timeout)
- Prints tab-separated `<url>\t<version>`, showing `unknown` for unreachable relays

## Test plan
- [x] `go build ./cmd/portal-tunnel/` compiles successfully
- [x] All existing tests pass (`make test`)
- [x] `./portal-tunnel list` outputs relay URLs with version info