### PR TITLE
fix: clarify identity.json path

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,7 +26,7 @@ services:
       PORTAL_URL: ${PORTAL_URL:-https://localhost:${API_PORT:-4017}}
       BOOTSTRAPS: ${BOOTSTRAPS:-}
       DISCOVERY: ${DISCOVERY:-true}
-      IDENTITY_PATH: ${IDENTITY_PATH:-/portal-certs}
+      IDENTITY_PATH: ${IDENTITY_PATH:-/portal-certs/identity.json}
 
       # Listener ports (published to the host below)
       API_PORT: ${API_PORT:-4017}


### PR DESCRIPTION
Currently, Docker Compose Configuration points out root directory of portal certificates.
But, the identity file path should point out a specific target configuration file instead of pointing about a certificates top-level directory.

Please read this change carefully and reply if you would merge this patch, or not.
Also, please comment a valid reason when you reject this commit.

Thanks, Lee Yunjin.