### PR TITLE
Resolving timestamp contamination during multi-hop propagation 

### DIFF
--- a/portal/lease.go
+++ b/portal/lease.go
@@ -443,6 +443,7 @@ func (r *leaseRegistry) RegisterHopRoute(route *types.HopRoute, now time.Time) (
 		},
 		Hostname:           matchHostname,
 		Metadata:           route.Metadata.Copy(),
+		FirstSeenAt:        route.FirstSeenAt.UTC(),
 		ExpiresAt:          expiresAt,
 		hopToken:           matchToken,
 		hopNextOverlayIPv4: overlayIPv4,

--- a/sdk/api_client.go
+++ b/sdk/api_client.go
@@ -233,6 +233,7 @@ func (l *listener) syncHopRoutes(ctx context.Context, method string, expiresAt t
 
 	var syncErr error
 	for _, unsignedRoute := range orderedRoutes {
+		unsignedRoute.FirstSeenAt = expiresAt.Add(-30 * time.Second)
 		route, err := auth.SignHopRoute(method, unsignedRoute, l.identity, expiresAt)
 		if err != nil {
 			if method == http.MethodDelete {

--- a/types/api.go
+++ b/types/api.go
@@ -141,27 +141,27 @@ func HopRouteBytes(method string, route HopRoute) ([]byte, error) {
 		return nil, err
 	}
 	payload := struct {
-		Purpose           string          `json:"purpose"`
-		Method            string          `json:"method"`
-		OwnerPublicKey    string          `json:"owner_public_key"`
-		RelayURL          string          `json:"relay_url"`
-		MatchHostname     string          `json:"match_hostname"`
-		MatchToken        string          `json:"match_token"`
-		ForwardRelay      json.RawMessage `json:"forward_relay"`
-		ForwardToken      string          `json:"forward_token"`
+		Purpose             string          `json:"purpose"`
+		Method              string          `json:"method"`
+		OwnerPublicKey      string          `json:"owner_public_key"`
+		RelayURL            string          `json:"relay_url"`
+		MatchHostname       string          `json:"match_hostname"`
+		MatchToken          string          `json:"match_token"`
+		ForwardRelay        json.RawMessage `json:"forward_relay"`
+		ForwardToken        string          `json:"forward_token"`
 		FirstSeenAtUnixNano int64           `json:"first_seen_at_unix_nano"`
-		ExpiresAtUnixNano int64           `json:"expires_at_unix_nano"`
+		ExpiresAtUnixNano   int64           `json:"expires_at_unix_nano"`
 	}{
-		Purpose:           "portal hop route v1",
-		Method:            strings.ToUpper(strings.TrimSpace(method)),
-		OwnerPublicKey:    strings.TrimSpace(route.OwnerPublicKey),
-		RelayURL:          strings.TrimSpace(route.RelayURL),
-		MatchHostname:     strings.TrimSpace(route.MatchHostname),
-		MatchToken:        strings.TrimSpace(route.MatchToken),
-		ForwardRelay:      json.RawMessage(forwardRelay),
-		ForwardToken:      strings.TrimSpace(route.ForwardToken),
+		Purpose:             "portal hop route v1",
+		Method:              strings.ToUpper(strings.TrimSpace(method)),
+		OwnerPublicKey:      strings.TrimSpace(route.OwnerPublicKey),
+		RelayURL:            strings.TrimSpace(route.RelayURL),
+		MatchHostname:       strings.TrimSpace(route.MatchHostname),
+		MatchToken:          strings.TrimSpace(route.MatchToken),
+		ForwardRelay:        json.RawMessage(forwardRelay),
+		ForwardToken:        strings.TrimSpace(route.ForwardToken),
 		FirstSeenAtUnixNano: route.FirstSeenAt.UTC().UnixNano(),
-		ExpiresAtUnixNano: route.ExpiresAt.UTC().UnixNano(),
+		ExpiresAtUnixNano:   route.ExpiresAt.UTC().UnixNano(),
 	}
 	return json.Marshal(payload)
 }

--- a/types/api.go
+++ b/types/api.go
@@ -130,6 +130,7 @@ type HopRoute struct {
 	Metadata       LeaseMetadata   `json:"metadata,omitempty"`
 	ForwardRelay   RelayDescriptor `json:"forward_relay"`
 	ForwardToken   string          `json:"forward_token"`
+	FirstSeenAt    time.Time       `json:"first_seen_at,omitempty"`
 	ExpiresAt      time.Time       `json:"expires_at,omitempty"`
 	Signature      string          `json:"signature,omitempty"`
 }
@@ -148,6 +149,7 @@ func HopRouteBytes(method string, route HopRoute) ([]byte, error) {
 		MatchToken        string          `json:"match_token"`
 		ForwardRelay      json.RawMessage `json:"forward_relay"`
 		ForwardToken      string          `json:"forward_token"`
+		FirstSeenAtUnixNano int64           `json:"first_seen_at_unix_nano"`
 		ExpiresAtUnixNano int64           `json:"expires_at_unix_nano"`
 	}{
 		Purpose:           "portal hop route v1",
@@ -158,6 +160,7 @@ func HopRouteBytes(method string, route HopRoute) ([]byte, error) {
 		MatchToken:        strings.TrimSpace(route.MatchToken),
 		ForwardRelay:      json.RawMessage(forwardRelay),
 		ForwardToken:      strings.TrimSpace(route.ForwardToken),
+		FirstSeenAtUnixNano: route.FirstSeenAt.UTC().UnixNano(),
 		ExpiresAtUnixNano: route.ExpiresAt.UTC().UnixNano(),
 	}
 	return json.Marshal(payload)


### PR DESCRIPTION
All the others were reflected in the latest main, and in the current situation, I only corrected the timestamp break in the multi-hop. 