### PR TITLE
fix(overlay): reuse shared http.Transport in Overlay

### DIFF
--- a/portal/overlay/overlay.go
+++ b/portal/overlay/overlay.go
@@ -66,10 +66,12 @@ func NormalizeConfig(cfg Config) (Config, error) {
 }
 
 type Overlay struct {
-	cfg      Config
-	stack    *stack
-	listener net.Listener
-	server   *http.Server
+	cfg       Config
+	stack     *stack
+	listener  net.Listener
+	server    *http.Server
+	transport *http.Transport
+	client    *http.Client
 }
 
 func NewOverlay(cfg Config, handler http.Handler) (*Overlay, error) {
@@ -98,13 +100,26 @@ func NewOverlay(cfg Config, handler http.Handler) (*Overlay, error) {
 		ReadHeaderTimeout: 10 * time.Second,
 	}
 
+	transport := &http.Transport{
+		DialContext:           stack.DialContext,
+		TLSHandshakeTimeout:   10 * time.Second,
+		MaxIdleConns:          100,
+		IdleConnTimeout:       90 * time.Second,
+		ResponseHeaderTimeout: 30 * time.Second,
+		ExpectContinueTimeout: 1 * time.Second,
+		ForceAttemptHTTP2:     false,
+	}
+	client := &http.Client{Transport: transport}
+
 	publicCfg := cfg.Copy()
 	publicCfg.PrivateKey = ""
 	return &Overlay{
-		cfg:      publicCfg,
-		stack:    stack,
-		listener: listener,
-		server:   server,
+		cfg:       publicCfg,
+		stack:     stack,
+		listener:  listener,
+		server:    server,
+		transport: transport,
+		client:    client,
 	}, nil
 }
 
@@ -139,6 +154,9 @@ func (o *Overlay) Shutdown(ctx context.Context) error {
 			shutdownErr = errors.Join(shutdownErr, err)
 		}
 	}
+	if o.transport != nil {
+		o.transport.CloseIdleConnections()
+	}
 	if o.listener != nil {
 		err := o.listener.Close()
 		if err != nil && !errors.Is(err, net.ErrClosed) {
@@ -155,12 +173,7 @@ func (o *Overlay) Client() *http.Client {
 	if o == nil || o.stack == nil {
 		return nil
 	}
-	return &http.Client{
-		Transport: &http.Transport{
-			DialContext:       o.stack.DialContext,
-			ForceAttemptHTTP2: false,
-		},
-	}
+	return o.client
 }
 
 func (o *Overlay) DiscoverRelay(ctx context.Context, relay types.RelayDescriptor) (types.DiscoveryResponse, error) {


### PR DESCRIPTION
### 문제
- Overlay.Client()가 호출마다 새 http.Transport/http.Client를 생성
- Transport를 직접 생성 시 IdleConnTimeout이 zero value(=0, 무제한)로 초기화됨
- keep-alive conn은 idle 상태에서도 conn당 readLoop/writeLoop goroutine이 다음 read를 기다리며 block
- IdleConnTimeout이 없으면 idle conn이 만료로 닫히지 않아 goroutine이 종료되지 않고, goroutine 자체가 GC root이므로 Transport·conn까지 회수되지 않음
- 호출마다 새 Transport가 생기므로 풀 재사용도 불가 → goroutine·conn 수가 호출 횟수에 비례해 누적

### 분석
- pprof 프로파일링으로 readLoop/writeLoop 고루틴 누적 확인
- https://github.com/oesni/connprof 적용 후 릴레이 connection 누적 확인
```
# transportdebug overview @ 2026-05-01T03:15:10Z
total_live:      2430
total_active:    0
total_idle:      2430
total_in_flight: 0
by_host:
  - host=100.103.54.30:7777 total=270 active=0 idle=270 in_flight=0 proto=h1
  - host=100.108.248.5:7777 total=270 active=0 idle=270 in_flight=0 proto=h1
  - host=100.111.197.141:7777 total=270 active=0 idle=270 in_flight=0 proto=h1
  - host=100.117.179.204:7777 total=270 active=0 idle=270 in_flight=0 proto=h1
  - host=100.118.130.103:7777 total=270 active=0 idle=270 in_flight=0 proto=h1
  - host=100.118.180.129:7777 total=270 active=0 idle=270 in_flight=0 proto=h1
  - host=100.120.122.225:7777 total=270 active=0 idle=270 in_flight=0 proto=h1
  - host=100.87.184.19:7777 total=270 active=0 idle=270 in_flight=0 proto=h1
  - host=100.98.61.9:7777 total=270 active=0 idle=270 in_flight=0 proto=h1
  ```
  
### 해결
- NewOverlay에서 http.Transport/http.Client를 1회 생성하고 Overlay에 보관 → Client()는 공유 인스턴스 반환
- IdleConnTimeout: 90s, MaxIdleConns: 100으로 idle conn이 만료·회수되도록 설정 → readLoop/writeLoop goroutine 종료
- 보조 timeout 추가: ResponseHeaderTimeout: 30s, TLSHandshakeTimeout: 10s, ExpectContinueTimeout: 1s
- Shutdown에서 transport.CloseIdleConnections() 호출로 종료 시점 idle 풀 즉시 정리
