### PR TITLE
feat: add optional relay pprof server

### DIFF
--- a/cmd/relay-server/main.go
+++ b/cmd/relay-server/main.go
@@ -47,6 +47,8 @@ type relayServerConfig struct {
 	MaxPort            int
 	LandingPageEnabled bool
 	HeadlessShellURL   string
+	PProfEnabled       bool
+	PProfAddr          string
 
 	ACMEDNSProvider    string
 	ENSGaslessEnabled  bool
@@ -83,6 +85,8 @@ func runServeCommand(args []string) error {
 
 	utils.BoolFlagEnv(fs, &cfg.LandingPageEnabled, "landing-page-enabled", false, "enable landing page by default when no admin setting has been saved yet", "LANDING_PAGE_ENABLED")
 	utils.StringFlagEnv(fs, &cfg.HeadlessShellURL, "headless-shell-url", "", "headless Chrome CDP WebSocket URL for thumbnail generation (e.g. ws://headless-shell:9222)", "HEADLESS_SHELL_URL")
+	utils.BoolFlagEnv(fs, &cfg.PProfEnabled, "pprof-enabled", false, "enable pprof diagnostics HTTP server", "PPROF_ENABLED")
+	utils.StringFlagEnv(fs, &cfg.PProfAddr, "pprof-addr", portal.DefaultPProfListenAddr, "pprof diagnostics listen address when enabled", "PPROF_ADDR")
 
 	utils.StringFlagEnv(fs, &cfg.ACMEDNSProvider, "acme-dns-provider", "", "ACME DNS provider for managed DNS-01/A-record sync and ENS gasless DNSSEC/TXT automation (cloudflare|gcloud|route53); leave empty to use manual fullchain.pem/privatekey.pem from IDENTITY_PATH", "ACME_DNS_PROVIDER")
 	utils.BoolFlagEnv(fs, &cfg.ENSGaslessEnabled, "ens-gasless-enabled", false, "enable ENS gasless DNS import automation for the managed DNS zone and lease hostnames", "ENS_GASLESS_ENABLED")
@@ -125,6 +129,8 @@ func runServeCommand(args []string) error {
 		Int("max_port", cfg.MaxPort).
 		Bool("landing_page_enabled", cfg.LandingPageEnabled).
 		Bool("headless_shell_enabled", strings.TrimSpace(cfg.HeadlessShellURL) != "").
+		Bool("pprof_enabled", cfg.PProfEnabled).
+		Str("pprof_addr", cfg.PProfAddr).
 		Str("acme_dns_provider", cfg.ACMEDNSProvider).
 		Bool("ens_gasless_enabled", cfg.ENSGaslessEnabled).
 		Msg("configured relay server")
@@ -150,6 +156,8 @@ func runServer(ctx context.Context, cfg relayServerConfig) error {
 		TCPEnabled:        cfg.TCPEnabled,
 		MinPort:           cfg.MinPort,
 		MaxPort:           cfg.MaxPort,
+		PProfEnabled:      cfg.PProfEnabled,
+		PProfListenAddr:   cfg.PProfAddr,
 		ACME: acme.Config{
 			KeyDir:             cfg.IdentityPath,
 			DNSProvider:        cfg.ACMEDNSProvider,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,6 +21,8 @@ services:
       # - "${SNI_PORT:-443}:${SNI_PORT:-443}/udp"
       # - "${MIN_PORT:-40000}-${MAX_PORT:-40009}:${MIN_PORT:-40000}-${MAX_PORT:-40009}/udp"
       # - "${MIN_PORT:-40000}-${MAX_PORT:-40009}:${MIN_PORT:-40000}-${MAX_PORT:-40009}"
+      # Uncomment with PPROF_ENABLED=true and PPROF_ADDR=:6060 to inspect pprof from the host.
+      # - "${PPROF_PORT:-6060}:${PPROF_PORT:-6060}"
     environment:
       # Public routing, discovery, and relay identity persistence
       PORTAL_URL: ${PORTAL_URL:-https://localhost:${API_PORT:-4017}}
@@ -46,6 +48,10 @@ services:
 
       # Optional: auto-generated thumbnails (requires headless-shell sidecar above)
       # HEADLESS_SHELL_URL: ${HEADLESS_SHELL_URL:-ws://headless-shell:9222}
+
+      # Optional diagnostics; keep loopback unless the pprof port is protected.
+      PPROF_ENABLED: ${PPROF_ENABLED:-false}
+      PPROF_ADDR: ${PPROF_ADDR:-127.0.0.1:6060}
 
       # TLS/ACME materials
       ACME_DNS_PROVIDER: ${ACME_DNS_PROVIDER:-}

--- a/docs/src/routes/configuration/+page.md
+++ b/docs/src/routes/configuration/+page.md
@@ -58,6 +58,13 @@ The relay server (`relay-server`) reads configuration from environment variables
 |----------|---------|------|-------------|
 | `HEADLESS_SHELL_URL` | `""` | string | Headless Chrome CDP WebSocket URL for thumbnail generation (e.g. `ws://headless-shell:9222`) |
 
+### Diagnostics
+
+| Variable | Default | Type | Description |
+|----------|---------|------|-------------|
+| `PPROF_ENABLED` | `false` | bool | Enable the relay pprof diagnostics HTTP server |
+| `PPROF_ADDR` | `127.0.0.1:6060` | string | pprof listen address when enabled; keep it on loopback unless the port is protected |
+
 ### Cloudflare
 
 | Variable | Default | Type | Description |

--- a/portal/server.go
+++ b/portal/server.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"net/http/pprof"
 	"strings"
 	"sync"
 	"time"
@@ -33,6 +34,7 @@ const (
 	defaultClientHelloWait  = 2 * time.Second
 	defaultControlBodyLimit = 4 << 20
 	defaultHopOpenRetryWait = 250 * time.Millisecond
+	DefaultPProfListenAddr  = "127.0.0.1:6060"
 )
 
 type ServerConfig struct {
@@ -51,6 +53,8 @@ type ServerConfig struct {
 	TCPEnabled        bool
 	MinPort           int
 	MaxPort           int
+	PProfEnabled      bool
+	PProfListenAddr   string
 	ACME              acme.Config
 }
 
@@ -82,6 +86,9 @@ func normalizeServerConfig(cfg ServerConfig) (ServerConfig, error) {
 	cfg.WireGuardPort = utils.IntOrDefault(cfg.WireGuardPort, overlay.DefaultListenPort)
 	cfg.APIListenAddr = utils.StringOrDefault(cfg.APIListenAddr, fmt.Sprintf(":%d", cfg.APIPort))
 	cfg.SNIListenAddr = utils.StringOrDefault(cfg.SNIListenAddr, fmt.Sprintf(":%d", cfg.SNIPort))
+	if cfg.PProfEnabled {
+		cfg.PProfListenAddr = utils.StringOrDefault(strings.TrimSpace(cfg.PProfListenAddr), DefaultPProfListenAddr)
+	}
 
 	hasPortRange := cfg.MinPort > 0 && cfg.MaxPort > 0
 	if cfg.UDPEnabled || cfg.TCPEnabled {
@@ -110,11 +117,13 @@ type Server struct {
 	acmeManager *acme.Manager
 	proxy       proxy
 
-	apiListener  net.Listener
-	sniListener  net.Listener
-	apiServer    *http.Server
-	apiTLSClose  io.Closer
-	quicBackhaul *quic.Listener
+	apiListener   net.Listener
+	sniListener   net.Listener
+	apiServer     *http.Server
+	apiTLSClose   io.Closer
+	pprofListener net.Listener
+	pprofServer   *http.Server
+	quicBackhaul  *quic.Listener
 
 	overlay         *overlay.Overlay
 	hopMux          *overlay.HopMux
@@ -173,6 +182,8 @@ func (s *Server) Start(ctx context.Context, apiMux *http.ServeMux) error {
 	var sniListener net.Listener
 	var apiServer *http.Server
 	var apiCloser io.Closer
+	var pprofListener net.Listener
+	var pprofServer *http.Server
 	var hopMux *overlay.HopMux
 	var ov *overlay.Overlay
 	var quicBackhaul *quic.Listener
@@ -189,6 +200,12 @@ func (s *Server) Start(ctx context.Context, apiMux *http.ServeMux) error {
 		}
 		if apiServer != nil {
 			_ = apiServer.Close()
+		}
+		if pprofServer != nil {
+			_ = pprofServer.Close()
+		}
+		if pprofListener != nil {
+			_ = pprofListener.Close()
 		}
 		if apiCloser != nil {
 			_ = apiCloser.Close()
@@ -217,6 +234,22 @@ func (s *Server) Start(ctx context.Context, apiMux *http.ServeMux) error {
 	if err != nil {
 		return err
 	}
+	if s.cfg.PProfEnabled {
+		pprofListener, err = listenConfig.Listen(serverCtx, "tcp", s.cfg.PProfListenAddr)
+		if err != nil {
+			return fmt.Errorf("listen pprof: %w", err)
+		}
+		pprofMux := http.NewServeMux()
+		pprofMux.HandleFunc("/debug/pprof/", pprof.Index)
+		pprofMux.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
+		pprofMux.HandleFunc("/debug/pprof/profile", pprof.Profile)
+		pprofMux.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
+		pprofMux.HandleFunc("/debug/pprof/trace", pprof.Trace)
+		pprofServer = &http.Server{
+			Handler:           pprofMux,
+			ReadHeaderTimeout: 10 * time.Second,
+		}
+	}
 
 	if s.relaySet != nil && strings.TrimSpace(s.identity.WireGuardPrivateKey) != "" {
 		ov, err = s.startOverlay()
@@ -240,6 +273,8 @@ func (s *Server) Start(ctx context.Context, apiMux *http.ServeMux) error {
 	s.sniListener = sniListener
 	s.apiServer = apiServer
 	s.apiTLSClose = apiCloser
+	s.pprofListener = pprofListener
+	s.pprofServer = pprofServer
 	s.acmeManager = acmeManager
 	s.cancel = cancel
 	s.group = group
@@ -249,6 +284,9 @@ func (s *Server) Start(ctx context.Context, apiMux *http.ServeMux) error {
 	started = true
 
 	group.Go(s.runAPIServer)
+	if s.pprofServer != nil {
+		group.Go(s.runPProfServer)
+	}
 	group.Go(func() error { return s.runPublicIngress(groupCtx) })
 	if s.overlay != nil {
 		group.Go(s.overlay.Serve)
@@ -282,7 +320,11 @@ func (s *Server) Start(ctx context.Context, apiMux *http.ServeMux) error {
 		Bool("wireguard_enabled", s.overlay != nil).
 		Bool("multihop_enabled", s.hopMux != nil).
 		Bool("udp_enabled", s.quicBackhaul != nil).
-		Bool("tcp_enabled", s.cfg.TCPEnabled)
+		Bool("tcp_enabled", s.cfg.TCPEnabled).
+		Bool("pprof_enabled", s.pprofServer != nil)
+	if s.pprofListener != nil {
+		logEvent = logEvent.Str("pprof_addr", utils.HostPortOrLoopback(s.pprofListener.Addr().String()))
+	}
 	if s.quicBackhaul != nil {
 		logEvent = logEvent.Str("internal_quic_backhaul_addr", s.quicBackhaul.Addr().String())
 	}
@@ -361,6 +403,11 @@ func (s *Server) Shutdown(ctx context.Context) error {
 				shutdownErr = err
 			}
 		}
+		if s.pprofServer != nil {
+			if err := s.pprofServer.Shutdown(ctx); err != nil && shutdownErr == nil {
+				shutdownErr = err
+			}
+		}
 		if s.hopMux != nil {
 			if err := s.hopMux.Close(); err != nil && shutdownErr == nil && !errors.Is(err, net.ErrClosed) {
 				shutdownErr = err
@@ -412,6 +459,14 @@ func (s *Server) prepareAPITLS(ctx context.Context) (keyless.TLSMaterialConfig, 
 
 func (s *Server) runAPIServer() error {
 	err := s.apiServer.Serve(s.apiListener)
+	if err == nil || errors.Is(err, http.ErrServerClosed) || errors.Is(err, net.ErrClosed) {
+		return nil
+	}
+	return err
+}
+
+func (s *Server) runPProfServer() error {
+	err := s.pprofServer.Serve(s.pprofListener)
 	if err == nil || errors.Is(err, http.ErrServerClosed) || errors.Is(err, net.ErrClosed) {
 		return nil
 	}

--- a/portal/server_test.go
+++ b/portal/server_test.go
@@ -172,6 +172,45 @@ func TestServerStartInitializesLocalACMEAndSigner(t *testing.T) {
 	}
 }
 
+func TestServerStartEnablesPProfOnSeparateHTTPListener(t *testing.T) {
+	t.Parallel()
+
+	server, err := NewServer(ServerConfig{
+		PortalURL:       "https://localhost:4017",
+		IdentityPath:    tempIdentityPath(t),
+		ACME:            acme.Config{KeyDir: t.TempDir()},
+		APIListenAddr:   "127.0.0.1:0",
+		SNIListenAddr:   "127.0.0.1:0",
+		PProfEnabled:    true,
+		PProfListenAddr: "127.0.0.1:0",
+	})
+	if err != nil {
+		t.Fatalf("NewServer() error = %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	if err := server.Start(ctx, nil); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+
+	client := newTestClient(t, cancel, server)
+	if server.pprofListener == nil {
+		t.Fatal("pprofListener = nil, want listener")
+	}
+
+	resp, err := client.Get("http://" + utils.HostPortOrLoopback(server.pprofListener.Addr().String()) + "/debug/pprof/")
+	if err != nil {
+		t.Fatalf("GET /debug/pprof/ error = %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("GET /debug/pprof/ status = %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+}
+
 func TestServerStartDomainReportsCompatibilityInfo(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
  ## Summary
  - Add optional pprof diagnostics server for relay debugging.
  - Gate pprof behind `PPROF_ENABLED` / `--pprof-enabled`.
  - Serve pprof on a separate HTTP listener configured by `PPROF_ADDR` / `--pprof-addr`, defaulting to `127.0.0.1:6060`.

  ## Notes
  - pprof is disabled by default.
  - The default bind address is loopback to avoid exposing diagnostics publicly.
