### PR TITLE
feat(relay): improve registry resilience for server bootstrap

### DIFF
--- a/portal/server.go
+++ b/portal/server.go
@@ -9,6 +9,8 @@ import (
 	"net"
 	"net/http"
 	"net/http/pprof"
+	"os"
+	"path/filepath"
 	"strings"
 	"sync"
 	"time"
@@ -148,7 +150,7 @@ func NewServer(cfg ServerConfig) (*Server, error) {
 	}
 	var relaySet *discovery.RelaySet
 	if cfg.DiscoveryEnabled {
-		cfg.Bootstraps, err = utils.ResolvePortalRelayURLs(context.Background(), cfg.Bootstraps, true)
+		cfg.Bootstraps, err = resolveDiscoveryBootstraps(context.Background(), cfg.IdentityPath, cfg.Bootstraps)
 		if err != nil {
 			return nil, fmt.Errorf("resolve discovery bootstraps: %w", err)
 		}
@@ -165,6 +167,35 @@ func NewServer(cfg ServerConfig) (*Server, error) {
 	}
 	server.registry.proxy = &server.proxy
 	return server, nil
+}
+
+func resolveDiscoveryBootstraps(ctx context.Context, stateDir string, explicit []string) ([]string, error) {
+	explicit, err := utils.NormalizeRelayURLs(explicit...)
+	if err != nil {
+		return nil, err
+	}
+
+	bootstraps, err := utils.ResolvePortalRelayURLs(ctx, explicit, true)
+	if err != nil {
+		return nil, err
+	}
+	if len(bootstraps) > len(explicit) {
+		return bootstraps, nil
+	}
+
+	registryPath := filepath.Join(stateDir, types.RelayRegistryFilename)
+	log.Warn().Str("path", registryPath).Msg("relay registry fetch failed; falling back to local registry file")
+	local, err := utils.LoadLocalRelayRegistry(registryPath)
+	switch {
+	case err == nil:
+		log.Info().Str("path", registryPath).Int("relays", len(local)).Msg("loaded relay registry from local fallback")
+		return utils.MergeRelayURLs(local, nil, explicit)
+	case os.IsNotExist(err):
+		log.Warn().Str("path", registryPath).Msg("local relay registry fallback file not found")
+	default:
+		log.Warn().Err(err).Str("path", registryPath).Msg("local relay registry fallback failed")
+	}
+	return bootstraps, nil
 }
 
 func (s *Server) Start(ctx context.Context, apiMux *http.ServeMux) error {

--- a/portal/server.go
+++ b/portal/server.go
@@ -9,8 +9,6 @@ import (
 	"net"
 	"net/http"
 	"net/http/pprof"
-	"os"
-	"path/filepath"
 	"strings"
 	"sync"
 	"time"
@@ -150,7 +148,7 @@ func NewServer(cfg ServerConfig) (*Server, error) {
 	}
 	var relaySet *discovery.RelaySet
 	if cfg.DiscoveryEnabled {
-		cfg.Bootstraps, err = resolveDiscoveryBootstraps(context.Background(), cfg.IdentityPath, cfg.Bootstraps)
+		cfg.Bootstraps, err = utils.ResolveDiscoveryBootstraps(context.Background(), cfg.IdentityPath, cfg.Bootstraps)
 		if err != nil {
 			return nil, fmt.Errorf("resolve discovery bootstraps: %w", err)
 		}
@@ -167,35 +165,6 @@ func NewServer(cfg ServerConfig) (*Server, error) {
 	}
 	server.registry.proxy = &server.proxy
 	return server, nil
-}
-
-func resolveDiscoveryBootstraps(ctx context.Context, stateDir string, explicit []string) ([]string, error) {
-	explicit, err := utils.NormalizeRelayURLs(explicit...)
-	if err != nil {
-		return nil, err
-	}
-
-	bootstraps, err := utils.ResolvePortalRelayURLs(ctx, explicit, true)
-	if err != nil {
-		return nil, err
-	}
-	if len(bootstraps) > len(explicit) {
-		return bootstraps, nil
-	}
-
-	registryPath := filepath.Join(stateDir, types.RelayRegistryFilename)
-	log.Warn().Str("path", registryPath).Msg("relay registry fetch failed; falling back to local registry file")
-	local, err := utils.LoadLocalRelayRegistry(registryPath)
-	switch {
-	case err == nil:
-		log.Info().Str("path", registryPath).Int("relays", len(local)).Msg("loaded relay registry from local fallback")
-		return utils.MergeRelayURLs(local, nil, explicit)
-	case os.IsNotExist(err):
-		log.Warn().Str("path", registryPath).Msg("local relay registry fallback file not found")
-	default:
-		log.Warn().Err(err).Str("path", registryPath).Msg("local relay registry fallback failed")
-	}
-	return bootstraps, nil
 }
 
 func (s *Server) Start(ctx context.Context, apiMux *http.ServeMux) error {

--- a/types/types.go
+++ b/types/types.go
@@ -10,6 +10,8 @@ const (
 	MarkerKeepalive   = byte(0x00)
 	MarkerRawStart    = byte(0x01)
 	MarkerTLSStart    = byte(0x02)
+
+	RelayRegistryFilename = "registry.json"
 )
 
 func PortalRelayRegistryURLs() []string {

--- a/types/types.go
+++ b/types/types.go
@@ -10,13 +10,4 @@ const (
 	MarkerKeepalive   = byte(0x00)
 	MarkerRawStart    = byte(0x01)
 	MarkerTLSStart    = byte(0x02)
-
-	RelayRegistryFilename = "registry.json"
 )
-
-func PortalRelayRegistryURLs() []string {
-	return []string{
-		"https://raw.githubusercontent.com/gosuda/portal-tunnel/main/registry.json",
-		"https://object.rly.best/portal-tunnel/registry.json",
-	}
-}

--- a/types/types.go
+++ b/types/types.go
@@ -1,7 +1,7 @@
 package types
 
 const (
-	ReleaseVersion         = "v2.1.9"
+	ReleaseVersion         = "v2.1.10"
 	SDKVersion             = "6"
 	DiscoveryVersion       = "7"
 	OfficialReleaseBaseURL = "https://github.com/gosuda/portal-tunnel/releases"

--- a/types/types.go
+++ b/types/types.go
@@ -4,7 +4,6 @@ const (
 	ReleaseVersion         = "v2.1.9"
 	SDKVersion             = "6"
 	DiscoveryVersion       = "7"
-	PortalRelayRegistryURL = "https://raw.githubusercontent.com/gosuda/portal-tunnel/main/registry.json"
 	OfficialReleaseBaseURL = "https://github.com/gosuda/portal-tunnel/releases"
 
 	HeaderAccessToken = "X-Portal-Access-Token"
@@ -12,3 +11,10 @@ const (
 	MarkerRawStart    = byte(0x01)
 	MarkerTLSStart    = byte(0x02)
 )
+
+func PortalRelayRegistryURLs() []string {
+	return []string{
+		"https://raw.githubusercontent.com/gosuda/portal-tunnel/main/registry.json",
+		"https://object.rly.best/portal-tunnel/registry.json",
+	}
+}

--- a/utils/network.go
+++ b/utils/network.go
@@ -150,28 +150,36 @@ func ResolvePortalRelayURLs(ctx context.Context, explicit []string, includeDefau
 		return explicit, nil
 	}
 
+	// TODO(@oesni): do not create a new client for each call
 	client := NewHTTPClient(WithHTTPTimeout(3 * time.Second))
-	var registry struct {
-		Relays []string `json:"relays"`
+	for _, registryURL := range types.PortalRelayRegistryURLs() {
+		defaults, ok := fetchRelayRegistry(ctx, client, registryURL)
+		if !ok {
+			continue
+		}
+		return MergeRelayURLs(defaults, nil, explicit)
 	}
-	resp, err := httpDo(ctx, client, http.MethodGet, types.PortalRelayRegistryURL, nil, nil)
+	return explicit, nil
+}
+
+func fetchRelayRegistry(ctx context.Context, client *http.Client, registryURL string) ([]string, bool) {
+	resp, err := httpDo(ctx, client, http.MethodGet, registryURL, nil, nil)
 	if err != nil {
-		return explicit, nil
+		return nil, false
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
-		return explicit, nil
+		return nil, false
+	}
+	var registry struct {
+		Relays []string `json:"relays"`
 	}
 	if err := json.NewDecoder(resp.Body).Decode(&registry); err != nil {
-		return explicit, nil
+		return nil, false
 	}
-
 	defaults, err := NormalizeRelayURLs(registry.Relays...)
-	if err != nil {
-		return explicit, nil
+	if err != nil || len(defaults) == 0 {
+		return nil, false
 	}
-	if len(defaults) == 0 {
-		return explicit, nil
-	}
-	return MergeRelayURLs(defaults, nil, explicit)
+	return defaults, true
 }

--- a/utils/network.go
+++ b/utils/network.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"net"
 	"net/http"
@@ -153,8 +154,8 @@ func ResolvePortalRelayURLs(ctx context.Context, explicit []string, includeDefau
 	// TODO(@oesni): do not create a new client for each call
 	client := NewHTTPClient(WithHTTPTimeout(3 * time.Second))
 	for _, registryURL := range types.PortalRelayRegistryURLs() {
-		defaults, ok := fetchRelayRegistry(ctx, client, registryURL)
-		if !ok {
+		defaults, err := fetchRelayRegistry(ctx, client, registryURL)
+		if err != nil {
 			continue
 		}
 		return MergeRelayURLs(defaults, nil, explicit)
@@ -162,24 +163,27 @@ func ResolvePortalRelayURLs(ctx context.Context, explicit []string, includeDefau
 	return explicit, nil
 }
 
-func fetchRelayRegistry(ctx context.Context, client *http.Client, registryURL string) ([]string, bool) {
+func fetchRelayRegistry(ctx context.Context, client *http.Client, registryURL string) ([]string, error) {
 	resp, err := httpDo(ctx, client, http.MethodGet, registryURL, nil, nil)
 	if err != nil {
-		return nil, false
+		return nil, err
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
-		return nil, false
+		return nil, fmt.Errorf("unexpected status %s", resp.Status)
 	}
 	var registry struct {
 		Relays []string `json:"relays"`
 	}
 	if err := json.NewDecoder(resp.Body).Decode(&registry); err != nil {
-		return nil, false
+		return nil, fmt.Errorf("decode registry: %w", err)
 	}
 	defaults, err := NormalizeRelayURLs(registry.Relays...)
-	if err != nil || len(defaults) == 0 {
-		return nil, false
+	if err != nil {
+		return nil, fmt.Errorf("normalize relays: %w", err)
 	}
-	return defaults, true
+	if len(defaults) == 0 {
+		return nil, errors.New("registry contained no relay urls")
+	}
+	return defaults, nil
 }

--- a/utils/network.go
+++ b/utils/network.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"io"
 	"net"
 	"net/http"
@@ -142,48 +141,3 @@ func FetchRelayVersion(ctx context.Context, relayURL string) string {
 	return envelope.Data.ReleaseVersion
 }
 
-func ResolvePortalRelayURLs(ctx context.Context, explicit []string, includeDefaults bool) ([]string, error) {
-	explicit, err := NormalizeRelayURLs(explicit...)
-	if err != nil {
-		return nil, err
-	}
-	if !includeDefaults {
-		return explicit, nil
-	}
-
-	// TODO(@oesni): do not create a new client for each call
-	client := NewHTTPClient(WithHTTPTimeout(3 * time.Second))
-	for _, registryURL := range types.PortalRelayRegistryURLs() {
-		defaults, err := fetchRelayRegistry(ctx, client, registryURL)
-		if err != nil {
-			continue
-		}
-		return MergeRelayURLs(defaults, nil, explicit)
-	}
-	return explicit, nil
-}
-
-func fetchRelayRegistry(ctx context.Context, client *http.Client, registryURL string) ([]string, error) {
-	resp, err := httpDo(ctx, client, http.MethodGet, registryURL, nil, nil)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("unexpected status %s", resp.Status)
-	}
-	var registry struct {
-		Relays []string `json:"relays"`
-	}
-	if err := json.NewDecoder(resp.Body).Decode(&registry); err != nil {
-		return nil, fmt.Errorf("decode registry: %w", err)
-	}
-	defaults, err := NormalizeRelayURLs(registry.Relays...)
-	if err != nil {
-		return nil, fmt.Errorf("normalize relays: %w", err)
-	}
-	if len(defaults) == 0 {
-		return nil, errors.New("registry contained no relay urls")
-	}
-	return defaults, nil
-}

--- a/utils/registry.go
+++ b/utils/registry.go
@@ -58,12 +58,12 @@ func ResolveDiscoveryBootstraps(ctx context.Context, stateDir string, explicit [
 	return bootstraps, nil
 }
 
-func ResolvePortalRelayURLs(ctx context.Context, explicit []string, includeDefaults bool) ([]string, error) {
+func ResolvePortalRelayURLs(ctx context.Context, explicit []string, fetchRegistry bool) ([]string, error) {
 	explicit, err := NormalizeRelayURLs(explicit...)
 	if err != nil {
 		return nil, err
 	}
-	if !includeDefaults {
+	if !fetchRegistry {
 		return explicit, nil
 	}
 

--- a/utils/registry.go
+++ b/utils/registry.go
@@ -1,13 +1,70 @@
 package utils
 
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/gosuda/portal-tunnel/v2/types"
+)
+
+type relayRegistry struct {
+	Relays []string `json:"relays"`
+}
+
+func ResolvePortalRelayURLs(ctx context.Context, explicit []string, includeDefaults bool) ([]string, error) {
+	explicit, err := NormalizeRelayURLs(explicit...)
+	if err != nil {
+		return nil, err
+	}
+	if !includeDefaults {
+		return explicit, nil
+	}
+
+	// TODO(@oesni): do not create a new client for each call
+	client := NewHTTPClient(WithHTTPTimeout(3 * time.Second))
+	for _, registryURL := range types.PortalRelayRegistryURLs() {
+		defaults, err := fetchRelayRegistry(ctx, client, registryURL)
+		if err != nil {
+			continue
+		}
+		return MergeRelayURLs(defaults, nil, explicit)
+	}
+	return explicit, nil
+}
+
 // LoadLocalRelayRegistry reads a registry.json file with the
 // {"relays": [...]} envelope and returns the normalized relay URLs.
 func LoadLocalRelayRegistry(path string) ([]string, error) {
-	var registry struct {
-		Relays []string `json:"relays"`
-	}
+	var registry relayRegistry
 	if err := ReadJSONFile(path, &registry); err != nil {
 		return nil, err
 	}
 	return NormalizeRelayURLs(registry.Relays...)
+}
+
+func fetchRelayRegistry(ctx context.Context, client *http.Client, registryURL string) ([]string, error) {
+	resp, err := httpDo(ctx, client, http.MethodGet, registryURL, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected status %s", resp.Status)
+	}
+	var registry relayRegistry
+	if err := json.NewDecoder(resp.Body).Decode(&registry); err != nil {
+		return nil, fmt.Errorf("decode registry: %w", err)
+	}
+	defaults, err := NormalizeRelayURLs(registry.Relays...)
+	if err != nil {
+		return nil, fmt.Errorf("normalize relays: %w", err)
+	}
+	if len(defaults) == 0 {
+		return nil, errors.New("registry contained no relay urls")
+	}
+	return defaults, nil
 }

--- a/utils/registry.go
+++ b/utils/registry.go
@@ -6,13 +6,49 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"os"
+	"path/filepath"
 	"time"
+
+	"github.com/rs/zerolog/log"
 
 	"github.com/gosuda/portal-tunnel/v2/types"
 )
 
 type relayRegistry struct {
 	Relays []string `json:"relays"`
+}
+
+// ResolveDiscoveryBootstraps resolves the bootstrap relay URL set for relay
+// discovery: explicit URLs merged with the public registry, falling back to
+// <stateDir>/registry.json when every registry endpoint is unreachable.
+func ResolveDiscoveryBootstraps(ctx context.Context, stateDir string, explicit []string) ([]string, error) {
+	explicit, err := NormalizeRelayURLs(explicit...)
+	if err != nil {
+		return nil, err
+	}
+
+	bootstraps, err := ResolvePortalRelayURLs(ctx, explicit, true)
+	if err != nil {
+		return nil, err
+	}
+	if len(bootstraps) > len(explicit) {
+		return bootstraps, nil
+	}
+
+	registryPath := filepath.Join(stateDir, types.RelayRegistryFilename)
+	log.Warn().Str("path", registryPath).Msg("relay registry fetch failed; falling back to local registry file")
+	local, err := LoadLocalRelayRegistry(registryPath)
+	switch {
+	case err == nil:
+		log.Info().Str("path", registryPath).Int("relays", len(local)).Msg("loaded relay registry from local fallback")
+		return MergeRelayURLs(local, nil, explicit)
+	case os.IsNotExist(err):
+		log.Warn().Str("path", registryPath).Msg("local relay registry fallback file not found")
+	default:
+		log.Warn().Err(err).Str("path", registryPath).Msg("local relay registry fallback failed")
+	}
+	return bootstraps, nil
 }
 
 func ResolvePortalRelayURLs(ctx context.Context, explicit []string, includeDefaults bool) ([]string, error) {

--- a/utils/registry.go
+++ b/utils/registry.go
@@ -1,0 +1,13 @@
+package utils
+
+// LoadLocalRelayRegistry reads a registry.json file with the
+// {"relays": [...]} envelope and returns the normalized relay URLs.
+func LoadLocalRelayRegistry(path string) ([]string, error) {
+	var registry struct {
+		Relays []string `json:"relays"`
+	}
+	if err := ReadJSONFile(path, &registry); err != nil {
+		return nil, err
+	}
+	return NormalizeRelayURLs(registry.Relays...)
+}

--- a/utils/registry.go
+++ b/utils/registry.go
@@ -11,9 +11,16 @@ import (
 	"time"
 
 	"github.com/rs/zerolog/log"
-
-	"github.com/gosuda/portal-tunnel/v2/types"
 )
+
+const RelayRegistryFilename = "registry.json"
+
+func PortalRelayRegistryURLs() []string {
+	return []string{
+		"https://raw.githubusercontent.com/gosuda/portal-tunnel/main/registry.json",
+		"https://object.rly.best/portal-tunnel/registry.json",
+	}
+}
 
 type relayRegistry struct {
 	Relays []string `json:"relays"`
@@ -36,7 +43,7 @@ func ResolveDiscoveryBootstraps(ctx context.Context, stateDir string, explicit [
 		return bootstraps, nil
 	}
 
-	registryPath := filepath.Join(stateDir, types.RelayRegistryFilename)
+	registryPath := filepath.Join(stateDir, RelayRegistryFilename)
 	log.Warn().Str("path", registryPath).Msg("relay registry fetch failed; falling back to local registry file")
 	local, err := LoadLocalRelayRegistry(registryPath)
 	switch {
@@ -62,7 +69,7 @@ func ResolvePortalRelayURLs(ctx context.Context, explicit []string, includeDefau
 
 	// TODO(@oesni): do not create a new client for each call
 	client := NewHTTPClient(WithHTTPTimeout(3 * time.Second))
-	for _, registryURL := range types.PortalRelayRegistryURLs() {
+	for _, registryURL := range PortalRelayRegistryURLs() {
 		defaults, err := fetchRelayRegistry(ctx, client, registryURL)
 		if err != nil {
 			continue


### PR DESCRIPTION
## Summary

### Behavior changes
- **Multi-registry fallback**: `ResolvePortalRelayURLs` now iterates `PortalRelayRegistryURLs()` (raw.githubusercontent.com + object.rly.best) and uses the first registry that responds with a usable list, instead of failing silently when a single GitHub raw URL is unreachable.
- **Server bootstrap logging + local file fallback**: `NewServer` now resolves discovery bootstraps via `utils.ResolveDiscoveryBootstraps`, which logs when every public registry fails and falls back to `<state-dir>/registry.json` before settling on the explicit-only set. A registry outage no longer silently lands the server with zero discovery bootstraps.

### Refactors
- Consolidate all relay-registry helpers into a new `utils/registry.go`:
  - `ResolvePortalRelayURLs`, `ResolveDiscoveryBootstraps`, `LoadLocalRelayRegistry`, `fetchRelayRegistry`
  - `RelayRegistryFilename`, `PortalRelayRegistryURLs()` (moved out of `types/types.go`)
  - Shared `relayRegistry` envelope type to remove duplicated inline structs.
- Rename `ResolvePortalRelayURLs`'s `includeDefaults` parameter to `fetchRegistry` to surface what the flag actually gates (the registry HTTP fetch).

## Test plan
- [x] `go build ./... && go vet ./...`
- [x] `go test ./utils/... ./portal/...`
- [ ] Manually verify warn logs surface when all registries fail and a local `registry.json` is missing / present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)