### PR TITLE
Add local multi-hop relay test harness

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help install fmt vet lint lint-auto test vuln tidy all run build build-frontend build-docs build-tunnel build-server clean load-test
+.PHONY: help install fmt vet lint lint-auto test test-local-multihop vuln tidy all run build build-frontend build-docs build-tunnel build-server clean load-test
 
 .DEFAULT_GOAL := help
 
@@ -15,6 +15,8 @@ help:
 	@echo "  make install           - Install Go developer tools used by this repo"
 	@echo "  make fmt               - Apply gofmt/goimports"
 	@echo "  make lint-auto         - Run autofix lint/format pipeline"
+	@echo "  make test              - Run Go tests, including the local multi-hop harness"
+	@echo "  make test-local-multihop - Run the focused local multi-hop relay harness"
 	@echo "  make build             - Build everything (frontend, tunnel, server)"
 	@echo "  make build-frontend    - Build React frontend (Tailwind CSS 4)"
 	@echo "  make build-docs        - Build documentation site (SvelteKit)"
@@ -45,6 +47,9 @@ lint-auto:
 
 test:
 	go test -v -coverprofile=coverage.out $(GO_PACKAGES)
+
+test-local-multihop:
+	go test -v ./portal -run 'TestLocalCluster'
 
 vuln:
 	govulncheck $(GO_PACKAGES)

--- a/docs/src/routes/architecture/+page.md
+++ b/docs/src/routes/architecture/+page.md
@@ -300,6 +300,14 @@ Result: raw public UDP exposure with an internal QUIC datagram backhaul. UDP and
 - The overlay peer API is plain HTTP on the WireGuard network, not public Internet HTTP. It serves the same discovery payload shape used by public `/discovery`.
 - Overlay failure affects inter-relay discovery, mesh synchronization, and multi-hop relay forwarding. Direct tenant TLS routing, keyless TLS, register/renew/connect, and public UDP ingress do not depend on the WireGuard transport path.
 
+### Local multi-hop test harness
+
+`portal/multihop_local_test.go` verifies the multi-hop relay path inside one `go test` process. It starts local relay servers on `127.0.0.1:0`, seeds signed local discovery descriptors, and uses test fakes only for the WireGuard transport layer.
+
+Use `make test-local-multihop` for the focused local harness. The same tests are also included in `make test` through the `./portal/...` package set. Use `go test ./portal ./sdk` when checking the narrower portal and SDK interaction without the full repository test suite.
+
+The harness exercises SDK expose/register logic, `/sdk/hop`, `RelaySet`, signed descriptors, route registration, SNI ingress, hop token matching, and `bridgeLeaseConn`. It intentionally excludes public DNS, ACME provider side effects, public registry bootstrap, and real WireGuard devices. `localRelaySpec` provides relay-level server and descriptor mutation hooks for future policy tests, and the fake overlay records synced peers so fake hop streams only open after the `/sdk/hop` overlay sync path has run.
+
 ## Control Plane Flow
 
 ### 1. Register

--- a/portal/api_server.go
+++ b/portal/api_server.go
@@ -332,7 +332,7 @@ func (s *Server) handleRegisterChallenge(w http.ResponseWriter, r *http.Request)
 		Path:   types.PathSDKRegister,
 	}).String()
 
-	if strings.TrimSpace(req.HopToken) != "" && s.overlay == nil {
+	if strings.TrimSpace(req.HopToken) != "" && !s.hasHopTransport() {
 		utils.WriteAPIError(w, http.StatusServiceUnavailable, types.APIErrorCodeFeatureUnavailable, errFeatureUnavailable.Error())
 		return
 	}
@@ -406,7 +406,7 @@ func (s *Server) handleHop(w http.ResponseWriter, r *http.Request) {
 		utils.MethodNotAllowedError().Write(w)
 		return
 	}
-	if s.overlay == nil || s.relaySet == nil {
+	if !s.hasHopTransport() || !s.hasOverlayRuntime() || s.relaySet == nil {
 		utils.WriteAPIError(w, http.StatusServiceUnavailable, types.APIErrorCodeFeatureUnavailable, errFeatureUnavailable.Error())
 		return
 	}
@@ -459,7 +459,7 @@ func (s *Server) handleHop(w http.ResponseWriter, r *http.Request) {
 		utils.InvalidRequestError(fmt.Errorf("forward relay: %w", err)).Write(w)
 		return
 	}
-	if err := s.overlay.Sync(s.relaySet.OverlayPeerStates()); err != nil {
+	if err := s.syncOverlayPeers(s.relaySet.OverlayPeerStates()); err != nil {
 		utils.WriteAPIError(w, http.StatusInternalServerError, types.APIErrorCodeInternal, err.Error())
 		return
 	}

--- a/portal/discovery/refresher.go
+++ b/portal/discovery/refresher.go
@@ -161,10 +161,26 @@ func (r *Refresher) refreshHTTPS(ctx context.Context) error {
 			}
 			continue
 		}
+		client := r.httpClient
+		var closeClient func()
+		if utils.IsLocalRelayHost(baseURL.Hostname()) {
+			_, localClient, transport, err := utils.NewHTTPTLSClient(ctx, baseURL, defaultRequestTimeout)
+			if err != nil {
+				if recoveryFailures > 0 {
+					r.logDiscoveryFailure(relayURL, relayURL, recoveryFailures, err)
+				}
+				continue
+			}
+			client = localClient
+			closeClient = transport.CloseIdleConnections
+		}
 
 		startedAt := time.Now()
 		var resp types.DiscoveryResponse
-		if err := utils.HTTPDoAPIPath(ctx, r.httpClient, baseURL, http.MethodGet, types.PathDiscovery, nil, nil, &resp); err != nil {
+		if err := utils.HTTPDoAPIPath(ctx, client, baseURL, http.MethodGet, types.PathDiscovery, nil, nil, &resp); err != nil {
+			if closeClient != nil {
+				closeClient()
+			}
 			if ctx.Err() != nil {
 				return ctx.Err()
 			}
@@ -172,6 +188,9 @@ func (r *Refresher) refreshHTTPS(ctx context.Context) error {
 				r.logDiscoveryFailure(relayURL, relayURL, recoveryFailures, err)
 			}
 			continue
+		}
+		if closeClient != nil {
+			closeClient()
 		}
 		measuredAt := time.Now().UTC()
 

--- a/portal/lease.go
+++ b/portal/lease.go
@@ -438,6 +438,7 @@ func (r *leaseRegistry) Renew(req types.RenewRequest, clientIP string) (types.Re
 	if strings.TrimSpace(reportedIP) != "" {
 		record.ReportedIP = reportedIP
 	}
+	record.Metadata = req.Metadata.Copy()
 	r.policy.IPFilter().RegisterIdentityIP(leaseKey, clientIP)
 	identity := record.Identity
 	r.mu.Unlock()

--- a/portal/multihop_local_test.go
+++ b/portal/multihop_local_test.go
@@ -1,0 +1,459 @@
+package portal
+
+import (
+	"bufio"
+	"context"
+	"crypto/tls"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"slices"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/gosuda/portal-tunnel/v2/portal/acme"
+	"github.com/gosuda/portal-tunnel/v2/portal/auth"
+	"github.com/gosuda/portal-tunnel/v2/portal/discovery"
+	"github.com/gosuda/portal-tunnel/v2/portal/overlay"
+	"github.com/gosuda/portal-tunnel/v2/sdk"
+	"github.com/gosuda/portal-tunnel/v2/types"
+	"github.com/gosuda/portal-tunnel/v2/utils"
+)
+
+type localRelayCluster struct {
+	relays []*localRelay
+	byIP   map[string]*localRelay
+}
+
+type localRelaySpec struct {
+	Name              string
+	ServerMutator     func(*Server)
+	DescriptorMutator func(*types.RelayDescriptor)
+}
+
+type localRelay struct {
+	name              string
+	server            *Server
+	apiURL            string
+	sniAddr           string
+	overlayIP         string
+	overlay           *fakeOverlay
+	descriptorMutator func(*types.RelayDescriptor)
+}
+
+type fakeOverlay struct {
+	cfg       overlay.Config
+	mu        sync.RWMutex
+	syncedIPs map[string]struct{}
+}
+
+func (o *fakeOverlay) Config() overlay.Config {
+	return o.cfg.Copy()
+}
+
+func (o *fakeOverlay) Sync(states []discovery.RelayState) error {
+	synced := make(map[string]struct{}, len(states))
+	for _, state := range states {
+		overlayIP, err := utils.DeriveWireGuardOverlayIPv4(state.Descriptor.WireGuardPublicKey)
+		if err != nil {
+			return err
+		}
+		synced[overlayIP] = struct{}{}
+	}
+	o.mu.Lock()
+	o.syncedIPs = synced
+	o.mu.Unlock()
+	return nil
+}
+
+func (o *fakeOverlay) hasSyncedPeer(overlayIPv4 string) bool {
+	o.mu.RLock()
+	defer o.mu.RUnlock()
+	_, ok := o.syncedIPs[overlayIPv4]
+	return ok
+}
+
+type fakeHopMux struct {
+	cluster *localRelayCluster
+	overlay *fakeOverlay
+}
+
+func (m *fakeHopMux) OpenStream(ctx context.Context, overlayIPv4, token string) (net.Conn, error) {
+	if m == nil || m.cluster == nil {
+		return nil, errors.New("fake hop mux is not connected to a cluster")
+	}
+	if m.overlay == nil || !m.overlay.hasSyncedPeer(overlayIPv4) {
+		return nil, fmt.Errorf("fake hop target %q was not synced to overlay", overlayIPv4)
+	}
+	target := m.cluster.byIP[overlayIPv4]
+	if target == nil {
+		return nil, fmt.Errorf("fake hop target %q not found", overlayIPv4)
+	}
+	left, right := net.Pipe()
+	go target.bridgeFakeHop(ctx, right, token)
+	return left, nil
+}
+
+func (r *localRelay) bridgeFakeHop(ctx context.Context, conn net.Conn, token string) {
+	r.server.registry.mu.RLock()
+	record := r.server.registry.recordByHopToken(token, time.Now())
+	r.server.registry.mu.RUnlock()
+	if record == nil {
+		_ = conn.Close()
+		return
+	}
+	if err := r.server.bridgeLeaseConn(ctx, conn, record); err != nil {
+		_ = conn.Close()
+	}
+}
+
+func newLocalRelayCluster(t *testing.T, names ...string) *localRelayCluster {
+	t.Helper()
+	specs := make([]localRelaySpec, 0, len(names))
+	for _, name := range names {
+		specs = append(specs, localRelaySpec{Name: name})
+	}
+	return newLocalRelayClusterFromSpecs(t, specs...)
+}
+
+func newLocalRelayClusterFromSpecs(t *testing.T, specs ...localRelaySpec) *localRelayCluster {
+	t.Helper()
+	if len(specs) == 0 {
+		t.Fatal("local relay cluster requires at least one relay")
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cluster := &localRelayCluster{
+		relays: make([]*localRelay, 0, len(specs)),
+		byIP:   make(map[string]*localRelay, len(specs)),
+	}
+	t.Cleanup(func() {
+		cancel()
+		for _, relay := range cluster.relays {
+			_ = relay.server.Shutdown(context.Background())
+			if err := relay.server.Wait(); err != nil {
+				t.Fatalf("relay %s Wait() error = %v", relay.name, err)
+			}
+		}
+	})
+
+	for _, spec := range specs {
+		relay := startLocalRelay(t, ctx, spec)
+		cluster.relays = append(cluster.relays, relay)
+	}
+	cluster.seedDiscovery(t)
+	return cluster
+}
+
+func startLocalRelay(t *testing.T, ctx context.Context, spec localRelaySpec) *localRelay {
+	t.Helper()
+	name := spec.Name
+	if name == "" {
+		t.Fatal("local relay spec name is required")
+	}
+	server, err := NewServer(ServerConfig{
+		PortalURL:     "https://localhost:4017",
+		IdentityPath:  tempIdentityPath(t),
+		ACME:          acme.Config{KeyDir: t.TempDir()},
+		APIListenAddr: "127.0.0.1:0",
+		SNIListenAddr: "127.0.0.1:0",
+	})
+	if err != nil {
+		t.Fatalf("NewServer(%s) error = %v", name, err)
+	}
+	if err := server.Start(ctx, nil); err != nil {
+		t.Fatalf("Start(%s) error = %v", name, err)
+	}
+
+	apiPort := mustPort(t, server.apiListener.Addr().String())
+	sniPort := mustPort(t, server.sniListener.Addr().String())
+	apiURL := "https://localhost:" + apiPort
+	server.cfg.PortalURL = apiURL
+	server.cfg.SNIPort = mustAtoi(t, sniPort)
+	server.registry.sniPort = server.cfg.SNIPort
+	if spec.ServerMutator != nil {
+		spec.ServerMutator(server)
+	}
+
+	wgPrivate, err := utils.GenerateWireGuardPrivateKey()
+	if err != nil {
+		t.Fatalf("GenerateWireGuardPrivateKey(%s) error = %v", name, err)
+	}
+	wgPublic, err := utils.WireGuardPublicKeyFromPrivate(wgPrivate)
+	if err != nil {
+		t.Fatalf("WireGuardPublicKeyFromPrivate(%s) error = %v", name, err)
+	}
+	fakeOverlay := &fakeOverlay{cfg: overlay.Config{
+		PublicKey:  wgPublic,
+		ListenPort: overlay.DefaultListenPort,
+	}}
+	fakeHopMux := &fakeHopMux{overlay: fakeOverlay}
+	server.testHooks = &serverTestHooks{
+		overlayConfig:    fakeOverlay.Config,
+		syncOverlayPeers: fakeOverlay.Sync,
+		openHopStream:    fakeHopMux.OpenStream,
+	}
+	server.cfg.DiscoveryEnabled = true
+
+	overlayIP, err := utils.DeriveWireGuardOverlayIPv4(wgPublic)
+	if err != nil {
+		t.Fatalf("DeriveWireGuardOverlayIPv4(%s) error = %v", name, err)
+	}
+	return &localRelay{
+		name:              name,
+		server:            server,
+		apiURL:            apiURL,
+		sniAddr:           net.JoinHostPort("127.0.0.1", sniPort),
+		overlayIP:         overlayIP,
+		overlay:           fakeOverlay,
+		descriptorMutator: spec.DescriptorMutator,
+	}
+}
+
+func (c *localRelayCluster) seedDiscovery(t *testing.T) {
+	t.Helper()
+	urls := make([]string, 0, len(c.relays))
+	descriptors := make([]types.RelayDescriptor, 0, len(c.relays))
+	for _, relay := range c.relays {
+		urls = append(urls, relay.apiURL)
+		desc, err := relay.server.newSelfDescriptor(time.Now())
+		if err != nil {
+			t.Fatalf("newSelfDescriptor(%s) error = %v", relay.name, err)
+		}
+		if relay.descriptorMutator != nil {
+			relay.descriptorMutator(&desc)
+			desc, err = auth.SignRelayDescriptor(desc, relay.server.identity.PrivateKey)
+			if err != nil {
+				t.Fatalf("SignRelayDescriptor(%s) error = %v", relay.name, err)
+			}
+		}
+		descriptors = append(descriptors, desc)
+		c.byIP[relay.overlayIP] = relay
+	}
+	for _, relay := range c.relays {
+		relay.server.relaySet = discovery.NewRelaySet(urls)
+		fakeHopMux := &fakeHopMux{cluster: c, overlay: relay.overlay}
+		relay.server.testHooks.openHopStream = fakeHopMux.OpenStream
+		changed, err := relay.server.relaySet.ApplyRelayDiscoveryResponse(relay.apiURL, types.DiscoveryResponse{
+			ProtocolVersion: types.DiscoveryVersion,
+			GeneratedAt:     time.Now().UTC(),
+			Relays:          descriptors,
+		}, time.Now())
+		if err != nil {
+			t.Fatalf("ApplyRelayDiscoveryResponse(%s) error = %v", relay.name, err)
+		}
+		if !changed {
+			t.Fatalf("ApplyRelayDiscoveryResponse(%s) changed = false, want true", relay.name)
+		}
+	}
+}
+
+func (c *localRelayCluster) relay(index int) *localRelay {
+	return c.relays[index]
+}
+
+func (c *localRelayCluster) relayURLs() []string {
+	out := make([]string, 0, len(c.relays))
+	for _, relay := range c.relays {
+		out = append(out, relay.apiURL)
+	}
+	return out
+}
+
+func (c *localRelayCluster) exposeMultiHop(t *testing.T, ctx context.Context, name string) *sdk.Exposure {
+	t.Helper()
+	exposure, err := sdk.Expose(ctx, sdk.ExposeConfig{
+		Name:       name,
+		TargetAddr: "127.0.0.1:1",
+		MultiHop:   c.relayURLs(),
+		BanMITM:    false,
+	})
+	if err != nil {
+		t.Fatalf("sdk.Expose() error = %v", err)
+	}
+	t.Cleanup(func() {
+		_ = exposure.Close()
+	})
+	return exposure
+}
+
+func TestLocalClusterExplicitMultiHopRegistersRoutes(t *testing.T) {
+	cluster := newLocalRelayCluster(t, "entry", "middle", "exit")
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+
+	exposure := cluster.exposeMultiHop(t, ctx, "local-hop")
+	waitForLocalHopRoutes(t, cluster, "local-hop.localhost")
+
+	if got := exposure.ActiveRelayURLs(); len(got) != 1 || got[0] != cluster.relay(2).apiURL {
+		t.Fatalf("ActiveRelayURLs() = %v, want exit relay %q", got, cluster.relay(2).apiURL)
+	}
+	entryRecord, ok := cluster.relay(0).server.registry.Lookup("local-hop.localhost")
+	if !ok {
+		t.Fatal("entry relay public hostname lookup failed")
+	}
+	if _, _, hasNext := entryRecord.nextHop(); !hasNext {
+		t.Fatal("entry relay route has no next hop")
+	}
+	if middle := firstRecord(cluster.relay(1).server, func(record *leaseRecord) bool {
+		return record.isHopMiddle()
+	}); middle == nil {
+		t.Fatal("middle relay hop route missing")
+	}
+	if exit := firstRecord(cluster.relay(2).server, func(record *leaseRecord) bool {
+		return record.isHopExit() && record.stream != nil
+	}); exit == nil {
+		t.Fatal("exit relay stream lease missing")
+	}
+}
+
+func TestLocalClusterPublicIngressTraversesFakeHopChain(t *testing.T) {
+	cluster := newLocalRelayCluster(t, "entry", "middle", "exit")
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+
+	exposure := cluster.exposeMultiHop(t, ctx, "local-http")
+	handlerReady := make(chan error, 1)
+	go func() {
+		handlerReady <- exposure.RunHTTP(ctx, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			_, _ = io.WriteString(w, "local multi-hop ok")
+		}), "")
+	}()
+	waitForLocalHopRoutes(t, cluster, "local-http.localhost")
+
+	body := requestThroughEntry(t, cluster.relay(0), "local-http.localhost")
+	if body != "local multi-hop ok" {
+		t.Fatalf("public ingress body = %q, want %q", body, "local multi-hop ok")
+	}
+
+	cancel()
+	if err := <-handlerReady; err != nil && !errors.Is(err, context.Canceled) {
+		t.Fatalf("RunHTTP() error = %v", err)
+	}
+}
+
+func TestLocalClusterDiscoveryStaysLocal(t *testing.T) {
+	cluster := newLocalRelayCluster(t, "entry", "middle", "exit")
+	want := cluster.relayURLs()
+	slices.Sort(want)
+
+	for _, relay := range cluster.relays {
+		self, err := relay.server.newSelfDescriptor(time.Now())
+		if err != nil {
+			t.Fatalf("newSelfDescriptor(%s) error = %v", relay.name, err)
+		}
+		descriptors := relay.server.relaySet.Descriptors(self)
+		got := make([]string, 0, len(descriptors))
+		for _, desc := range descriptors {
+			got = append(got, desc.APIHTTPSAddr)
+		}
+		slices.Sort(got)
+		if !slices.Equal(got, want) {
+			t.Fatalf("discovery relays for %s = %v, want local relays %v", relay.name, got, want)
+		}
+	}
+}
+
+func waitForLocalHopRoutes(t *testing.T, cluster *localRelayCluster, publicHostname string) {
+	t.Helper()
+	eventually(t, 10*time.Second, func() (bool, string) {
+		if _, ok := cluster.relay(0).server.registry.Lookup(publicHostname); !ok {
+			return false, "entry public route missing"
+		}
+		if firstRecord(cluster.relay(1).server, func(record *leaseRecord) bool { return record.isHopMiddle() }) == nil {
+			return false, "middle hop route missing"
+		}
+		if firstRecord(cluster.relay(2).server, func(record *leaseRecord) bool {
+			return record.isHopExit() && record.stream != nil && record.stream.ReadyCount() > 0
+		}) == nil {
+			return false, "exit stream lease not ready"
+		}
+		return true, ""
+	})
+}
+
+func firstRecord(server *Server, match func(*leaseRecord) bool) *leaseRecord {
+	server.registry.mu.RLock()
+	defer server.registry.mu.RUnlock()
+	for _, record := range server.registry.records {
+		if record != nil && match(record) {
+			return record
+		}
+	}
+	return nil
+}
+
+func requestThroughEntry(t *testing.T, entry *localRelay, serverName string) string {
+	t.Helper()
+	conn, err := tls.DialWithDialer(&net.Dialer{Timeout: 5 * time.Second}, "tcp", entry.sniAddr, &tls.Config{
+		MinVersion:         tls.VersionTLS12,
+		ServerName:         serverName,
+		InsecureSkipVerify: true,
+		NextProtos:         []string{"http/1.1"},
+	})
+	if err != nil {
+		t.Fatalf("dial entry SNI listener: %v", err)
+	}
+	defer conn.Close()
+
+	req, err := http.NewRequest(http.MethodGet, "https://"+serverName+"/", nil)
+	if err != nil {
+		t.Fatalf("NewRequest() error = %v", err)
+	}
+	if err := req.Write(conn); err != nil {
+		t.Fatalf("write HTTP request: %v", err)
+	}
+	resp, err := http.ReadResponse(bufioNewReader(conn), req)
+	if err != nil {
+		t.Fatalf("read HTTP response: %v", err)
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read HTTP response body: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("GET through entry status = %d body=%q, want 200", resp.StatusCode, string(body))
+	}
+	return string(body)
+}
+
+func eventually(t *testing.T, timeout time.Duration, check func() (bool, string)) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	var last string
+	for time.Now().Before(deadline) {
+		ok, reason := check()
+		if ok {
+			return
+		}
+		last = reason
+		time.Sleep(25 * time.Millisecond)
+	}
+	t.Fatalf("condition not met within %s: %s", timeout, last)
+}
+
+func mustPort(t *testing.T, addr string) string {
+	t.Helper()
+	_, port, err := net.SplitHostPort(addr)
+	if err != nil {
+		t.Fatalf("SplitHostPort(%q) error = %v", addr, err)
+	}
+	return port
+}
+
+func mustAtoi(t *testing.T, raw string) int {
+	t.Helper()
+	var out int
+	if _, err := fmt.Sscanf(raw, "%d", &out); err != nil {
+		t.Fatalf("parse int %q: %v", raw, err)
+	}
+	return out
+}
+
+func bufioNewReader(conn net.Conn) *bufio.Reader {
+	return bufio.NewReader(conn)
+}

--- a/portal/server.go
+++ b/portal/server.go
@@ -129,6 +129,13 @@ type Server struct {
 	relaySet        *discovery.RelaySet
 	announceLimiter *discovery.AnnounceLimiter
 	registry        *leaseRegistry
+	testHooks       *serverTestHooks
+}
+
+type serverTestHooks struct {
+	overlayConfig    func() overlay.Config
+	syncOverlayPeers func([]discovery.RelayState) error
+	openHopStream    func(context.Context, string, string) (net.Conn, error)
 }
 
 func NewServer(cfg ServerConfig) (*Server, error) {
@@ -553,9 +560,21 @@ func (s *Server) bridgeLeaseConn(ctx context.Context, conn net.Conn, record *lea
 
 		openCtx, cancel := context.WithTimeout(ctx, defaultClaimTimeout)
 		defer cancel()
-		next, err := s.overlay.OpenHopStream(openCtx, overlayIPv4, forwardToken)
-		if err != nil {
-			return fmt.Errorf("open next hop stream: %w", err)
+		var next net.Conn
+		var lastErr error
+		for {
+			var err error
+			next, err = s.openHopStream(openCtx, overlayIPv4, forwardToken)
+			if err == nil {
+				break
+			}
+			lastErr = err
+			if errors.Is(err, net.ErrClosed) {
+				return fmt.Errorf("open next hop stream: %w", err)
+			}
+			if !utils.SleepOrDone(openCtx, defaultHopOpenRetryWait) {
+				return fmt.Errorf("open next hop stream within %s: %w", defaultClaimTimeout, errors.Join(lastErr, openCtx.Err()))
+			}
 		}
 		s.proxy.bridge(conn, next, "", nil)
 		return nil
@@ -574,6 +593,53 @@ func (s *Server) bridgeLeaseConn(ctx context.Context, conn net.Conn, record *lea
 	}
 	s.proxy.bridge(conn, session, record.Key(), s.registry.policy.BPSManager())
 	return nil
+}
+
+func (s *Server) hasHopTransport() bool {
+	return s != nil && (s.overlay != nil || (s.testHooks != nil && s.testHooks.openHopStream != nil))
+}
+
+func (s *Server) hasOverlayRuntime() bool {
+	return s != nil && (s.overlay != nil || (s.testHooks != nil && s.testHooks.overlayConfig != nil && s.testHooks.syncOverlayPeers != nil))
+}
+
+func (s *Server) currentOverlayConfig() (overlay.Config, bool) {
+	if s == nil {
+		return overlay.Config{}, false
+	}
+	if s.overlay != nil {
+		return s.overlay.Config(), true
+	}
+	if s.testHooks != nil && s.testHooks.overlayConfig != nil {
+		return s.testHooks.overlayConfig(), true
+	}
+	return overlay.Config{}, false
+}
+
+func (s *Server) syncOverlayPeers(states []discovery.RelayState) error {
+	if s == nil {
+		return errors.New("server is unavailable")
+	}
+	if s.overlay != nil {
+		return s.overlay.Sync(states)
+	}
+	if s.testHooks != nil && s.testHooks.syncOverlayPeers != nil {
+		return s.testHooks.syncOverlayPeers(states)
+	}
+	return errors.New("relay overlay is unavailable")
+}
+
+func (s *Server) openHopStream(ctx context.Context, overlayIPv4, token string) (net.Conn, error) {
+	if s == nil {
+		return nil, errors.New("server is unavailable")
+	}
+	if s.overlay != nil {
+		return s.overlay.OpenHopStream(ctx, overlayIPv4, token)
+	}
+	if s.testHooks != nil && s.testHooks.openHopStream != nil {
+		return s.testHooks.openHopStream(ctx, overlayIPv4, token)
+	}
+	return nil, errors.New("relay overlay is unavailable")
 }
 
 func (s *Server) runRegistryJanitor(ctx context.Context, interval time.Duration) error {
@@ -751,10 +817,11 @@ func (s *Server) newSelfDescriptor(now time.Time) (types.RelayDescriptor, error)
 
 	var wireGuardPublicKey string
 	var wireGuardPort int
-	if s.overlay != nil {
-		cfg := s.overlay.Config()
+	supportsOverlay := false
+	if cfg, ok := s.currentOverlayConfig(); ok {
 		wireGuardPublicKey = cfg.PublicKey
 		wireGuardPort = cfg.ListenPort
+		supportsOverlay = true
 	}
 
 	return auth.SignRelayDescriptor(types.RelayDescriptor{
@@ -765,7 +832,7 @@ func (s *Server) newSelfDescriptor(now time.Time) (types.RelayDescriptor, error)
 		APIHTTPSAddr:       s.cfg.PortalURL,
 		WireGuardPublicKey: wireGuardPublicKey,
 		WireGuardPort:      wireGuardPort,
-		SupportsOverlay:    s.overlay != nil,
+		SupportsOverlay:    supportsOverlay,
 		SupportsUDP:        s.cfg.UDPEnabled && s.quicBackhaul != nil,
 		SupportsTCP:        s.cfg.TCPEnabled,
 		ActiveConnections:  s.proxy.activeConnectionCount(),

--- a/sdk/api_client.go
+++ b/sdk/api_client.go
@@ -237,14 +237,20 @@ func (l *listener) registerLease(ctx context.Context, ttl time.Duration, udpEnab
 
 func (l *listener) renewRegisteredLease(ctx context.Context, ttl time.Duration, accessToken string) (types.RenewResponse, error) {
 	var resp types.RenewResponse
-	if err := utils.HTTPDoAPIPath(ctx, l.httpClient, l.relayURL, http.MethodPost, types.PathSDKRenew, types.RenewRequest{
-		AccessToken: accessToken,
-		TTL:         int(ttl / time.Second),
-		ReportedIP:  utils.ResolvePublicIP(ctx),
-	}, nil, &resp); err != nil {
+	req := newRenewRequest(ttl, accessToken, utils.ResolvePublicIP(ctx), l.metadata)
+	if err := utils.HTTPDoAPIPath(ctx, l.httpClient, l.relayURL, http.MethodPost, types.PathSDKRenew, req, nil, &resp); err != nil {
 		return types.RenewResponse{}, err
 	}
 	return resp, nil
+}
+
+func newRenewRequest(ttl time.Duration, accessToken, reportedIP string, metadata types.LeaseMetadata) types.RenewRequest {
+	return types.RenewRequest{
+		AccessToken: accessToken,
+		TTL:         int(ttl / time.Second),
+		ReportedIP:  reportedIP,
+		Metadata:    metadata.Copy(),
+	}
 }
 
 func (l *listener) unregisterLease(ctx context.Context, accessToken string, hopRoutes []types.HopRoute) error {

--- a/sdk/api_client_test.go
+++ b/sdk/api_client_test.go
@@ -1,0 +1,39 @@
+package sdk
+
+import (
+	"testing"
+	"time"
+
+	"github.com/gosuda/portal-tunnel/v2/types"
+)
+
+func TestNewRenewRequestIncludesMetadata(t *testing.T) {
+	t.Parallel()
+
+	metadata := types.LeaseMetadata{
+		Description: "live app",
+		Tags:        []string{"demo", "live"},
+		Owner:       "ops",
+		Thumbnail:   "https://example.com/thumb.png",
+		Hide:        true,
+	}
+
+	req := newRenewRequest(2*time.Minute, "token", "203.0.113.10", metadata)
+	if req.AccessToken != "token" {
+		t.Fatalf("AccessToken = %q, want token", req.AccessToken)
+	}
+	if req.TTL != 120 {
+		t.Fatalf("TTL = %d, want 120", req.TTL)
+	}
+	if req.ReportedIP != "203.0.113.10" {
+		t.Fatalf("ReportedIP = %q, want 203.0.113.10", req.ReportedIP)
+	}
+	if got := req.Metadata; got.Description != metadata.Description || got.Owner != metadata.Owner || got.Thumbnail != metadata.Thumbnail || got.Hide != metadata.Hide || len(got.Tags) != 2 || got.Tags[0] != "demo" || got.Tags[1] != "live" {
+		t.Fatalf("Metadata = %#v, want %#v", got, metadata)
+	}
+
+	metadata.Tags[0] = "mutated"
+	if req.Metadata.Tags[0] != "demo" {
+		t.Fatalf("Metadata tags alias input slice: got %q", req.Metadata.Tags[0])
+	}
+}

--- a/sdk/expose.go
+++ b/sdk/expose.go
@@ -641,16 +641,7 @@ func (e *Exposure) reconcileRelayListeners(failOnError bool) error {
 	multiHop = append([]string(nil), e.multiHop...)
 	explicitRelays := append([]string(nil), e.explicitRelays...)
 	if len(multiHop) > 0 {
-		listenerRelayURLs = e.relaySet.PriorityRelays(discovery.ClientState{
-			ExplicitRelayURLs: explicitRelays,
-			MaxActiveRelays:   e.maxActiveRelays,
-			RequireUDP:        e.udpEnabled,
-			RequireTCP:        e.tcpEnabled,
-			LocalAddress:      e.identity.Address,
-		})
-		if exitRelayURL := multiHop[len(multiHop)-1]; !slices.Contains(listenerRelayURLs, exitRelayURL) {
-			listenerRelayURLs = append(listenerRelayURLs, exitRelayURL)
-		}
+		listenerRelayURLs = []string{multiHop[len(multiHop)-1]}
 	} else if e.multiHopDepth > 1 {
 		multiHop = e.relaySet.PriorityMultiHop(discovery.ClientState{
 			MultiHopDepth: e.multiHopDepth,

--- a/types/api.go
+++ b/types/api.go
@@ -110,9 +110,10 @@ type DiscoveryAnnounceResponse struct {
 }
 
 type RenewRequest struct {
-	AccessToken string `json:"access_token"`
-	TTL         int    `json:"ttl,omitempty"`
-	ReportedIP  string `json:"reported_ip,omitempty"`
+	AccessToken string        `json:"access_token"`
+	TTL         int           `json:"ttl,omitempty"`
+	ReportedIP  string        `json:"reported_ip,omitempty"`
+	Metadata    LeaseMetadata `json:"metadata,omitempty"`
 }
 
 type RenewResponse struct {


### PR DESCRIPTION
## Summary
- add a local multi-relay harness for explicit multi-hop route registration and ingress traversal
- allow tests to inject fake overlay and hop mux implementations while keeping production behavior unchanged
- document and expose the focused test command through Makefile

## Tests
- make test-local-multihop
- go test ./portal ./sdk