### PR TITLE
feat: add support for Sui testnet in x402 payment integration

### DIFF
--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -83,7 +83,7 @@ portal expose localhost:25565 --name minecraft --tcp
 portal expose 3000 --multi-hop-depth 3
 ```
 
-对于付费路由，支付策略运行在隧道进程内，而不是中继上。隧道会在同一个公共 origin 上提供 `/x402/client.js` 和 `/x402/prepare`。浏览器前端可以导入 `/x402/client.js` 并调用 `x402Fetch()`；原生客户端可以直接调用 `/x402/prepare`，用自己的 Sui 运行时签名返回的交易，并发送签名后的 `X-PAYMENT`。
+对于付费路由，支付策略运行在隧道进程内，而不是中继上。默认使用 Sui mainnet；加上 `--x402-testnet` 可切换到 Sui testnet，这个选择与中继自身的支付设置无关。隧道会在同一个公共 origin 上提供 `/x402/client.js` 和 `/x402/prepare`。浏览器前端可以导入 `/x402/client.js` 并调用 `x402Fetch()`；原生客户端可以直接调用 `/x402/prepare`，用自己的 Sui 运行时签名返回的交易，并发送签名后的 `X-PAYMENT`。
 
 完整路由语法请参阅 [CLI Reference](cmd/portal-tunnel/README.md)，x402 helper endpoint 请参阅 [API Reference](docs/src/routes/api-reference/+page.md#payments)。
 

--- a/cmd/portal-tunnel/README.md
+++ b/cmd/portal-tunnel/README.md
@@ -59,7 +59,8 @@ Routed HTTP serves `/x402/client.js` and `/x402/prepare` on the tunnel origin so
 an upstream browser frontend can run the same in-page Sui wallet payment flow as
 the standalone payment app. Native clients should use `/x402/prepare` directly
 and send the signed payload as `X-PAYMENT`. The tunnel still verifies and
-settles payment before proxying the paid route.
+settles payment before proxying the paid route. Paid routes use Sui mainnet by
+default; add `--x402-testnet` to use Sui testnet.
 
 Raw TCP and UDP:
 
@@ -101,6 +102,7 @@ Common `portal expose` flags:
 --hide               Hide service from relay listing screens
 --http-route         HTTP route mapping in PATH=UPSTREAM [METHOD[,METHOD...]:USDC_AMOUNT] form
 --x402-pay-to        Sui USDC payment recipient address for this tunnel
+--x402-testnet       Use Sui testnet for tunnel x402 payments
 --tcp                Request a dedicated raw TCP port on the relay
 --udp                Enable public UDP relay
 --udp-addr           Local UDP target
@@ -119,18 +121,19 @@ portal agent restart
 ```
 
 The dashboard can edit basic tunnel settings, relays, and multi-hop routes. Add
-Tunnel opens a small form for name, target or HTTP routes, relays, discovery,
-and max active relays. After creation, routed HTTP paths, route-level x402
-amounts, and discovery mode are read-only in the Settings pane. Edit
-`http_routes`, `x402_pay_to`, or `discovery` in TOML, then restart the agent or
-tunnel to change them.
+Tunnel opens a small form for name, target or HTTP routes, x402 pay-to/testnet,
+relays, discovery, and max active relays. After creation, routed HTTP paths,
+route-level x402 amounts, payment network, and discovery mode are read-only in
+the Settings pane. Edit `http_routes`, `x402_pay_to`, `x402_testnet`, or
+`discovery` in TOML, then restart the agent or tunnel to change them.
 
 ## Constraints
 
 - A positional `<target>` cannot be combined with `--http-route`.
 - `--http-route` cannot be combined with `--udp`.
 - Route payment amounts are USDC values such as `0.01`, are part of
-  `--http-route`, and require `--x402-pay-to`.
+  `--http-route`, and require `--x402-pay-to`; add `--x402-testnet` for Sui
+  testnet, otherwise payments use Sui mainnet.
 - `--multi-hop` cannot be combined with `--multi-hop-depth`.
 - Multi-hop currently supports only the default SNI TLS stream transport.
 - `--tcp` and `--udp` require matching relay transport support.

--- a/cmd/portal-tunnel/agent/config.go
+++ b/cmd/portal-tunnel/agent/config.go
@@ -60,6 +60,7 @@ type TunnelConfig struct {
 	Thumbnail       string            `koanf:"thumbnail"`
 	Hide            bool              `koanf:"hide"`
 	X402PayTo       string            `koanf:"x402_pay_to"`
+	X402Testnet     bool              `koanf:"x402_testnet"`
 }
 
 type HTTPRouteConfig struct {
@@ -217,6 +218,9 @@ func tunnelConfigDocumentMap(cfg TunnelConfig) map[string]any {
 		out["hide"] = cfg.Hide
 	}
 	addStringDocumentField(out, "x402_pay_to", cfg.X402PayTo)
+	if cfg.X402Testnet {
+		out["x402_testnet"] = cfg.X402Testnet
+	}
 	return out
 }
 

--- a/cmd/portal-tunnel/agent/dashboard.go
+++ b/cmd/portal-tunnel/agent/dashboard.go
@@ -61,6 +61,7 @@ const (
 	agentDashboardAddFieldTarget
 	agentDashboardAddFieldHTTPRoutes
 	agentDashboardAddFieldX402PayTo
+	agentDashboardAddFieldX402Testnet
 	agentDashboardAddFieldRelays
 	agentDashboardAddFieldDiscovery
 	agentDashboardAddFieldMaxRelays
@@ -99,15 +100,16 @@ type agentDashboardModel struct {
 	routeDraft    []string
 	draftTunnelID string
 
-	addingTunnel  bool
-	addFocus      int
-	addName       textinput.Model
-	addTarget     textinput.Model
-	addHTTPRoutes textinput.Model
-	addX402PayTo  textinput.Model
-	addRelays     textinput.Model
-	addDiscovery  textinput.Model
-	addMaxRelays  textinput.Model
+	addingTunnel   bool
+	addFocus       int
+	addName        textinput.Model
+	addTarget      textinput.Model
+	addHTTPRoutes  textinput.Model
+	addX402PayTo   textinput.Model
+	addX402Testnet textinput.Model
+	addRelays      textinput.Model
+	addDiscovery   textinput.Model
+	addMaxRelays   textinput.Model
 
 	settingsEditTunnelID string
 	settingsFocus        int
@@ -176,6 +178,7 @@ func RunDashboard(configPath, stateDir string) error {
 		addTarget:           newAgentDashboardInlineInput("3000"),
 		addHTTPRoutes:       newAgentDashboardInlineInput("/paid=3001 GET:0.01; /=5173"),
 		addX402PayTo:        newAgentDashboardInlineInput("0x..."),
+		addX402Testnet:      newAgentDashboardInlineInput("false"),
 		addRelays:           newAgentDashboardInlineInput("https://portal.example.com"),
 		addDiscovery:        newAgentDashboardInlineInput("true"),
 		addMaxRelays:        newAgentDashboardInlineInput("3"),
@@ -743,6 +746,8 @@ func (m *agentDashboardModel) focusedAddTunnelInput() *textinput.Model {
 		return &m.addHTTPRoutes
 	case agentDashboardAddFieldX402PayTo:
 		return &m.addX402PayTo
+	case agentDashboardAddFieldX402Testnet:
+		return &m.addX402Testnet
 	case agentDashboardAddFieldRelays:
 		return &m.addRelays
 	case agentDashboardAddFieldDiscovery:
@@ -760,6 +765,7 @@ func (m *agentDashboardModel) blurAddTunnelInputs() {
 		&m.addTarget,
 		&m.addHTTPRoutes,
 		&m.addX402PayTo,
+		&m.addX402Testnet,
 		&m.addRelays,
 		&m.addDiscovery,
 		&m.addMaxRelays,
@@ -774,12 +780,15 @@ func (m *agentDashboardModel) resetAddTunnelForm() {
 		&m.addTarget,
 		&m.addHTTPRoutes,
 		&m.addX402PayTo,
+		&m.addX402Testnet,
 		&m.addRelays,
 	} {
 		input.Reset()
 	}
+	m.addX402Testnet.SetValue("false")
 	m.addDiscovery.SetValue("true")
 	m.addMaxRelays.SetValue("3")
+	m.addX402Testnet.CursorEnd()
 	m.addDiscovery.CursorEnd()
 	m.addMaxRelays.CursorEnd()
 	m.addFocus = agentDashboardAddFieldName
@@ -893,6 +902,7 @@ func (m *agentDashboardModel) resizeInputs(width int) {
 		&m.addTarget,
 		&m.addHTTPRoutes,
 		&m.addX402PayTo,
+		&m.addX402Testnet,
 		&m.addRelays,
 		&m.addDiscovery,
 		&m.addMaxRelays,
@@ -996,6 +1006,17 @@ func (m agentDashboardModel) addTunnelRequest() (types.AgentTunnelRequest, error
 	if len(routes) == 0 && payTo != "" {
 		return types.AgentTunnelRequest{}, fmt.Errorf("X402 Pay To requires routes")
 	}
+	x402TestnetRaw := strings.TrimSpace(m.addX402Testnet.Value())
+	if x402TestnetRaw == "" {
+		x402TestnetRaw = "false"
+	}
+	x402Testnet, err := strconv.ParseBool(x402TestnetRaw)
+	if err != nil {
+		return types.AgentTunnelRequest{}, fmt.Errorf("X402 Testnet must be true or false")
+	}
+	if x402Testnet && !hasPaidRoute {
+		return types.AgentTunnelRequest{}, fmt.Errorf("X402 Testnet requires paid routes")
+	}
 
 	discoveryRaw := strings.TrimSpace(m.addDiscovery.Value())
 	if discoveryRaw == "" {
@@ -1023,6 +1044,7 @@ func (m agentDashboardModel) addTunnelRequest() (types.AgentTunnelRequest, error
 		Discovery:       &discovery,
 		MaxActiveRelays: maxRelays,
 		X402PayTo:       payTo,
+		X402Testnet:     x402Testnet,
 	}, nil
 }
 
@@ -1469,6 +1491,7 @@ func (m agentDashboardModel) renderAddTunnelForm(pane *agentDashboardView, width
 		{label: "Target", input: m.addTarget, field: agentDashboardAddFieldTarget},
 		{label: "Routes", input: m.addHTTPRoutes, field: agentDashboardAddFieldHTTPRoutes},
 		{label: "X402 Pay To", input: m.addX402PayTo, field: agentDashboardAddFieldX402PayTo},
+		{label: "X402 Testnet", input: m.addX402Testnet, field: agentDashboardAddFieldX402Testnet},
 		{label: "Relays", input: m.addRelays, field: agentDashboardAddFieldRelays},
 		{label: "Discovery", input: m.addDiscovery, field: agentDashboardAddFieldDiscovery},
 		{label: "Max Relays", input: m.addMaxRelays, field: agentDashboardAddFieldMaxRelays},
@@ -1615,6 +1638,12 @@ func (m agentDashboardModel) renderSettingsInputRows(pane *agentDashboardView, w
 			return
 		}
 		pane.addMeta(width, 0, "Pay To", payTo)
+	}
+	if payTo != "" || paidRouteCount > 0 {
+		if len(pane.lines)-startLine >= height {
+			return
+		}
+		pane.addMeta(width, 0, "Network", agentDashboardX402Network(tunnel.X402Testnet))
 	}
 	if len(tunnel.HTTPRoutes) == 0 {
 		if len(pane.lines)-startLine >= height {
@@ -2023,6 +2052,13 @@ func agentDashboardHTTPRouteSummary(route types.AgentHTTPRoute) string {
 		return fmt.Sprintf("%s -> %s (%s %s)", prefix, upstream, methods, amount)
 	}
 	return prefix + " -> " + upstream
+}
+
+func agentDashboardX402Network(testnet bool) string {
+	if testnet {
+		return "sui:testnet"
+	}
+	return "sui:mainnet"
 }
 
 func (m agentDashboardModel) settingsChanged(tunnel types.AgentTunnelStatus) bool {

--- a/cmd/portal-tunnel/agent/manager.go
+++ b/cmd/portal-tunnel/agent/manager.go
@@ -258,6 +258,7 @@ func (m *manager) AddTunnel(req types.AgentTunnelRequest) error {
 		Discovery:       &discovery,
 		MaxActiveRelays: req.MaxActiveRelays,
 		X402PayTo:       strings.TrimSpace(req.X402PayTo),
+		X402Testnet:     req.X402Testnet,
 	}
 	if slices.ContainsFunc(cfg.Tunnels, func(tunnel TunnelConfig) bool { return tunnel.ID == tunnelCfg.ID }) {
 		return fmt.Errorf("tunnel %q already exists", tunnelCfg.ID)
@@ -613,6 +614,7 @@ func (t *managedTunnel) Snapshot() types.AgentTunnelStatus {
 		Metadata:        metadataFromTunnelConfig(cfg),
 		MultiHop:        append([]string(nil), cfg.MultiHop...),
 		X402PayTo:       strings.TrimSpace(cfg.X402PayTo),
+		X402Testnet:     cfg.X402Testnet,
 	}
 	if len(cfg.HTTPRoutes) > 0 {
 		status.HTTPRoutes = make([]types.AgentHTTPRoute, 0, len(cfg.HTTPRoutes))
@@ -711,6 +713,7 @@ func (t *managedTunnel) runOnce(ctx context.Context) error {
 		MaxActiveRelays: cfg.MaxActiveRelays,
 		Metadata:        metadataFromTunnelConfig(cfg),
 		X402PayTo:       cfg.X402PayTo,
+		X402Testnet:     cfg.X402Testnet,
 	})
 	if err != nil {
 		return err

--- a/cmd/portal-tunnel/main.go
+++ b/cmd/portal-tunnel/main.go
@@ -60,6 +60,7 @@ type exposeFlags struct {
 	thumbnail       string
 	hide            bool
 	x402PayTo       string
+	x402Testnet     bool
 	targetAddr      string
 	httpRoutes      []string
 	udp             bool
@@ -89,6 +90,7 @@ func runExposeCommand(args []string) error {
 	utils.StringFlag(fs, &flags.thumbnail, "thumbnail", "", "Service thumbnail URL metadata")
 	utils.BoolFlag(fs, &flags.hide, "hide", false, "Hide service from relay listing screens")
 	utils.StringFlag(fs, &flags.x402PayTo, "x402-pay-to", "", "Sui USDC payment recipient address for this tunnel")
+	utils.BoolFlag(fs, &flags.x402Testnet, "x402-testnet", false, "Use Sui testnet for tunnel x402 payments; default is Sui mainnet")
 	utils.RepeatedStringFlag(fs, &flags.httpRoutes, "http-route", "HTTP route mapping in PATH=UPSTREAM [METHOD[,METHOD...]:USDC_AMOUNT] form; repeat to aggregate multiple local HTTP services behind one public URL")
 	utils.BoolFlagEnv(fs, &flags.udp, "udp", false, "Enable public UDP relay in addition to the default TCP relay", "UDP_ENABLED")
 	utils.StringFlagEnv(fs, &flags.udpAddr, "udp-addr", "", "Local UDP target address for relayed datagrams (host:port or port only); defaults to the target when --udp is enabled", "UDP_ADDR")
@@ -202,7 +204,8 @@ func runExposeCommand(args []string) error {
 			Thumbnail:   flags.thumbnail,
 			Hide:        flags.hide,
 		},
-		X402PayTo: flags.x402PayTo,
+		X402PayTo:   flags.x402PayTo,
+		X402Testnet: flags.x402Testnet,
 	})
 	if err != nil {
 		return fmt.Errorf("failed to start relays: %w", err)

--- a/cmd/relay-server/main.go
+++ b/cmd/relay-server/main.go
@@ -93,9 +93,9 @@ func runServeCommand(args []string) error {
 	utils.StringFlagEnv(fs, &cfg.AdminToken, "admin-token", "", "admin bearer token for relay admin and policy APIs", "ADMIN_TOKEN")
 	utils.BoolFlagEnv(fs, &cfg.PProfEnabled, "pprof-enabled", false, "enable pprof diagnostics HTTP server", "PPROF_ENABLED")
 	utils.StringFlagEnv(fs, &cfg.PProfAddr, "pprof-addr", portal.DefaultPProfListenAddr, "pprof diagnostics listen address when enabled", "PPROF_ADDR")
-	utils.BoolFlagEnv(fs, &cfg.X402Enabled, "x402-enabled", false, "enable embedded Sui x402 facilitator endpoints under /api/x402", "X402_ENABLED")
-	utils.BoolFlagEnv(fs, &cfg.X402Testnet, "x402-testnet", false, "use Sui testnet for embedded x402 facilitator payments", "X402_TESTNET")
-	utils.StringFlagEnv(fs, &cfg.X402PayTo, "x402-pay-to", "", "Sui payment recipient address for relay-owned x402 resources", "X402_PAY_TO")
+	utils.BoolFlagEnv(fs, &cfg.X402Enabled, "x402-enabled", false, "enable relay-owned Sui x402 facilitator endpoints under /api/x402 for future control-plane payments", "X402_ENABLED")
+	utils.BoolFlagEnv(fs, &cfg.X402Testnet, "x402-testnet", false, "use Sui testnet for relay-owned x402 facilitator payments", "X402_TESTNET")
+	utils.StringFlagEnv(fs, &cfg.X402PayTo, "x402-pay-to", "", "Sui payment recipient address for relay-owned control-plane x402 resources", "X402_PAY_TO")
 
 	utils.StringFlagEnv(fs, &cfg.ACMEDNSProvider, "acme-dns-provider", "", "DNS provider for managed DNS-01/A-record sync, ECH HTTPS records, and ENS gasless DNSSEC/TXT automation (cloudflare|gcloud|hetzner|njalla|route53|vultr); leave empty to use manual fullchain.pem/privatekey.pem from IDENTITY_PATH", "ACME_DNS_PROVIDER")
 	utils.BoolFlagEnv(fs, &cfg.ENSGaslessEnabled, "ens-gasless-enabled", false, "enable ENS gasless DNS import automation for the managed DNS zone and lease hostnames", "ENS_GASLESS_ENABLED")
@@ -213,7 +213,7 @@ func runServer(ctx context.Context, cfg relayServerConfig) error {
 		log.Info().
 			Str("path", types.PathX402Facilitator).
 			Str("network", x402Network).
-			Msg("embedded x402 facilitator enabled")
+			Msg("relay-owned x402 facilitator enabled")
 	}
 
 	if err := server.Start(ctx, apiMux); err != nil {

--- a/docs/src/routes/api-reference/+page.md
+++ b/docs/src/routes/api-reference/+page.md
@@ -40,7 +40,7 @@ The envelope does not apply to streaming or delegated endpoints:
 |------|--------|
 | `/sdk/connect` | HTTP/1.1 connection hijack |
 | `/v1/sign` | keyless TLS signer protocol |
-| `/api/x402/*` | embedded x402 facilitator response |
+| `/api/x402/*` | relay-owned x402 facilitator response |
 | `/api/install.sh`, `/api/install.ps1`, `/api/install/bin/*` | script or binary bytes |
 
 Unknown routes may be handled by the frontend/proxy layer or return a normal
@@ -114,18 +114,26 @@ SDK clients.
 
 ### Payments
 
-These Sui-only endpoints are available only when
-`X402_ENABLED=true`. They are served by the embedded
-`gosuda/x402-facilitator` handler and do not use the Portal JSON envelope.
-Portal selects Sui mainnet by default and Sui testnet when `X402_TESTNET=true`.
-Portal accepts only USDC gasless stablecoin address-balance payments.
-`X402_PAY_TO` is the relay-owned payment recipient. Tunnel payment recipients
-are local tunnel configuration and are not part of the relay lease API.
+Relay `/api/x402/*` endpoints are optional relay-owned control-plane
+facilitator endpoints. Enable them with `X402_ENABLED=true` when a relay
+operator wants to reserve support for relay resources such as future tunnel
+registration fees, lease renewal fees, raw TCP/UDP port allocation, or premium
+capacity. They are served by the embedded `gosuda/x402-facilitator` handler and
+do not use the Portal JSON envelope. Portal selects Sui mainnet by default and
+Sui testnet when `X402_TESTNET=true`. Portal accepts only USDC gasless
+stablecoin address-balance payments. `X402_PAY_TO` is the relay-owned payment
+recipient.
+
+Relay x402 settings do not affect tunnel paid routes. Tunnel payment recipients
+and payment networks are local tunnel configuration and are not part of the
+relay lease API.
 
 Paid routed HTTP tunnels additionally expose `/x402/prepare` and
 `/x402/client.js` on the public tunnel origin. Those are tunnel-owned helper
 endpoints for app frontends, not relay API routes, and they do not use the
-`/api` prefix. `/x402/client.js` is browser-only; native clients call
+`/api` prefix. Tunnel paid routes use Sui mainnet by default and Sui testnet
+when the tunnel is exposed with `--x402-testnet` or configured with
+`x402_testnet = true`. `/x402/client.js` is browser-only; native clients call
 `/x402/prepare` directly and send `X-PAYMENT` on the protected request.
 
 | Method | Path | Auth | Body | Response |

--- a/docs/src/routes/api-reference/sdk/+page.md
+++ b/docs/src/routes/api-reference/sdk/+page.md
@@ -12,7 +12,7 @@ that switches to a raw stream after a successful HTTP/1.1 response.
 
 ## Flow
 
-1. `GET /sdk/domain` checks relay compatibility, optional ENS support, and optional Sui x402 facilitator support.
+1. `GET /sdk/domain` checks relay compatibility, optional ENS support, and optional relay-owned Sui x402 control-plane facilitator support.
 2. `POST /sdk/register/challenge` creates a SIWE challenge for the requested identity.
 3. The SDK signs the returned `siwe_message`.
 4. `POST /sdk/register` exchanges the signature for a lease `access_token`.
@@ -39,7 +39,7 @@ that switches to a raw stream after a successful HTTP/1.1 response.
 | `protocol_version` | `string` | SDK tunnel protocol version |
 | `release_version` | `string` | relay software release |
 | `ens` | `ENSStatus` | gasless ENS status |
-| `x402` | `X402FacilitatorInfo` | embedded Sui x402 facilitator status |
+| `x402` | `X402FacilitatorInfo` | relay-owned Sui x402 control-plane facilitator status |
 
 `ENSStatus`:
 
@@ -54,6 +54,10 @@ that switches to a raw stream after a successful HTTP/1.1 response.
 |-------|------|
 | `enabled` | `boolean` |
 | `url`, `network`, `network_name`, `supported_url`, `pay_to` | `string` |
+
+This object describes the relay's own optional x402 facilitator for
+control-plane resources. It is separate from tunnel-owned routed HTTP payments,
+which are configured locally by the tunnel process.
 
 ## Register Challenge
 

--- a/docs/src/routes/cli-reference/+page.md
+++ b/docs/src/routes/cli-reference/+page.md
@@ -100,6 +100,7 @@ not supported.
 | `--owner` | string | | Service owner metadata |
 | `--hide` | bool | `false` | Hide service from relay listing screens |
 | `--x402-pay-to` | string | | Sui USDC payment recipient address for this tunnel |
+| `--x402-testnet` | bool | `false` | Use Sui testnet for tunnel x402 payments; default is Sui mainnet |
 | `--http-route` | string | | HTTP route mapping in `PATH=UPSTREAM [METHOD[,METHOD...]:USDC_AMOUNT]` form; repeatable; route amounts require `--x402-pay-to` |
 | `--tcp` | bool | `false` | Request a dedicated raw TCP port on the relay |
 | `--udp` | bool | `false` | Enable public UDP relay in addition to the default stream path |
@@ -115,6 +116,8 @@ not supported.
 - `--tcp` and `--udp` require matching transport support on the relay.
 - Route payment amounts are part of `--http-route` and require a tunnel-owned
   `--x402-pay-to`.
+- Tunnel paid routes use Sui mainnet by default; add `--x402-testnet` for Sui
+  testnet. This is independent of relay-owned x402 facilitator settings.
 
 ### Examples
 
@@ -216,7 +219,9 @@ const response = await x402Fetch('/paid/photo', { method: 'GET' }, {
 transaction, asks the wallet to sign it, then retries the protected request with
 an `X-PAYMENT` header. `onEvent` receives structured progress events; the older
 `onStatus(message)` callback is still accepted for simple UIs. Routed HTTP
-payments currently use Sui mainnet, so omit `network` or pass `sui:mainnet`.
+payments use Sui mainnet by default; pass `--x402-testnet` when exposing the
+tunnel and use `network: 'sui:testnet'` in wallet clients that need an explicit
+network. For mainnet, omit `network` or pass `sui:mainnet`.
 
 Native clients should not load `/x402/client.js`. Call `POST /x402/prepare` with
 `{ "sender": "...", "method": "GET", "path": "/paid/photo" }`, execute

--- a/docs/src/routes/concepts/+page.md
+++ b/docs/src/routes/concepts/+page.md
@@ -101,7 +101,8 @@ origin. A browser frontend mounted through the tunnel can import
 stays in the app instead of requiring a separate payment redirect. Native
 clients use `/x402/prepare` directly and send the signed payload as
 `X-PAYMENT`. The tunnel still verifies and settles the payment before proxying
-the protected request.
+the protected request. Paid routes use Sui mainnet by default; add
+`--x402-testnet` for Sui testnet.
 
 ## Dedicated Raw TCP
 

--- a/docs/src/routes/configuration/+page.md
+++ b/docs/src/routes/configuration/+page.md
@@ -41,9 +41,9 @@ The relay server (`relay-server`) reads configuration from environment variables
 
 | Variable | Default | Type | Description |
 |----------|---------|------|-------------|
-| `X402_ENABLED` | `false` | bool | Enable embedded Sui x402 facilitator endpoints under `/api/x402` |
-| `X402_TESTNET` | `false` | bool | Use Sui testnet for payments; `false` uses Sui mainnet |
-| `X402_PAY_TO` | `""` | string | Sui payment recipient address for relay-owned x402 resources |
+| `X402_ENABLED` | `false` | bool | Enable relay-owned Sui x402 facilitator endpoints under `/api/x402` for future control-plane payments |
+| `X402_TESTNET` | `false` | bool | Use Sui testnet for relay-owned x402 facilitator payments; `false` uses Sui mainnet |
+| `X402_PAY_TO` | `""` | string | Sui payment recipient address for relay-owned control-plane x402 resources |
 
 ### Proxy
 
@@ -163,6 +163,7 @@ The `portal expose` subcommand accepts the following flags. Flags that read from
 | `--thumbnail` | | string | | Service thumbnail URL metadata |
 | `--hide` | | bool | `false` | Hide service from relay listing screens |
 | `--x402-pay-to` | | string | | Sui USDC payment recipient address for this tunnel |
+| `--x402-testnet` | | bool | `false` | Use Sui testnet for tunnel x402 payments; default is Sui mainnet |
 
 ### Routing
 
@@ -221,6 +222,7 @@ tags = ["web"]
 id = "api"
 name = "myapp"
 x402_pay_to = "0x..."
+x402_testnet = true
 
 [[tunnels.http_routes]]
 prefix = "/api"
@@ -262,6 +264,7 @@ Tunnel fields mirror `portal expose` flags:
 | `udp`, `udp_addr`, `tcp` | bool/string | UDP and raw TCP relay options |
 | `description`, `tags`, `owner`, `thumbnail`, `hide` | mixed | Lease metadata shown by relays |
 | `x402_pay_to` | string | Tunnel-owned Sui USDC x402 payment recipient for paid HTTP routes |
+| `x402_testnet` | bool | Use Sui testnet for tunnel-owned x402 paid routes; omitted or `false` uses Sui mainnet |
 | `http_routes[].amount` | string | Optional Sui USDC x402 amount, such as `0.01`, for one HTTP route prefix; requires `x402_pay_to` |
 | `http_routes[].methods` | string array | Optional HTTP methods that require payment on that route; empty means every method |
 
@@ -271,7 +274,8 @@ frontends served by another route in the same tunnel can import
 `/x402/client.js` and use `x402Fetch()` to run the same Sui wallet payment flow
 as the standalone payment app. Native clients use `/x402/prepare` directly and
 send the signed payload as `X-PAYMENT`. Payment is still enforced by the tunnel
-on the paid route prefix.
+on the paid route prefix. Tunnel paid routes default to Sui mainnet and use Sui
+testnet when `x402_testnet = true`.
 
 For a task-oriented walkthrough, see [Portal Agent](/portal-agent).
 

--- a/docs/src/routes/portal-agent/+page.md
+++ b/docs/src/routes/portal-agent/+page.md
@@ -71,6 +71,7 @@ name = "myapp"
 relays = ["https://portal.example.com"]
 discovery = false
 x402_pay_to = "0x..."
+x402_testnet = true
 
 [[tunnels.http_routes]]
 prefix = "/api"
@@ -88,7 +89,8 @@ If a route has `amount`, the tunnel serves `/x402/client.js` and
 `/` route can import the helper and call `x402Fetch()` from its own UI. Native
 clients use `/x402/prepare` directly and send the signed payload as
 `X-PAYMENT`. The tunnel still verifies and settles payment before proxying the
-paid route.
+paid route. Paid routes use Sui mainnet by default; set `x402_testnet = true`
+to use Sui testnet.
 
 Relative paths in the config are resolved from the config file directory.
 
@@ -163,15 +165,17 @@ tunnel or `Routes` for routed HTTP. Routes use this syntax:
 /paid=3001 GET:0.01; /=5173
 ```
 
-Each entry is `PATH=UPSTREAM [METHOD[,METHOD...]:USDC_AMOUNT]`. Fill `X402 Pay To`
-when any route has an amount. The form also accepts explicit `Relays`,
+Each entry is `PATH=UPSTREAM [METHOD[,METHOD...]:USDC_AMOUNT]`. Fill `X402 Pay
+To` when any route has an amount, and set `X402 Testnet` to `true` for Sui
+testnet. The form also accepts explicit `Relays`,
 `Discovery`, and `Max Relays`; max relays caps auto-selected discovery relays
 while explicit relays are still included.
 
-After creation, routed HTTP paths, x402 payment amounts, and discovery mode are
-read-only in the Settings pane. To change routes, payment amounts, or discovery
-mode, edit `http_routes`, `x402_pay_to`, and `discovery` in `config.toml`, then
-restart the agent or tunnel. Other advanced options such as UDP, TCP, custom
+After creation, routed HTTP paths, x402 payment amounts, payment network, and
+discovery mode are read-only in the Settings pane. To change routes, payment
+amounts, payment network, or discovery mode, edit `http_routes`,
+`x402_pay_to`, `x402_testnet`, and `discovery` in `config.toml`, then restart
+the agent or tunnel. Other advanced options such as UDP, TCP, custom
 identity JSON, or explicit multi-hop defaults are also configured in
 `config.toml`.
 
@@ -197,6 +201,7 @@ Common fields:
 | `ban_mitm` | Ban relays when the TLS self-probe detects termination; defaults to warning-only |
 | `description`, `tags`, `owner`, `thumbnail`, `hide` | Public relay metadata |
 | `x402_pay_to` | Tunnel-owned Sui USDC x402 recipient for paid HTTP routes |
+| `x402_testnet` | Use Sui testnet for tunnel-owned x402 paid routes; omitted or `false` uses Sui mainnet |
 | `http_routes[].amount` | Optional Sui USDC x402 amount, such as `0.01`, for one HTTP route prefix |
 | `http_routes[].methods` | Optional HTTP methods that require payment on that route; empty means every method |
 

--- a/docs/src/routes/self-hosting/+page.md
+++ b/docs/src/routes/self-hosting/+page.md
@@ -85,11 +85,13 @@ docker compose up -d
 | `IDENTITY_PATH` | `./.portal-certs` | Relay state directory containing `identity.json`, `policy.json`, and TLS materials. |
 | `ADMIN_TOKEN` | | Bearer token source for relay admin and policy APIs. |
 
-## Optional: Enable Embedded Sui x402 Facilitator
+## Optional: Enable Relay-Owned Sui x402 Facilitator
 
-To expose Sui x402 facilitator endpoints from the relay process itself, enable
-the embedded handler. Payments use Sui mainnet by default; set
-`X402_TESTNET=true` for Sui testnet.
+To reserve relay-side x402 support for future control-plane resources, enable
+the relay-owned facilitator. This is intended for relay-owned charges such as
+tunnel registration, lease renewal, raw TCP/UDP port allocation, or premium
+capacity if an operator decides to require them. Payments use Sui mainnet by
+default; set `X402_TESTNET=true` for Sui testnet.
 
 ```yaml
 environment:
@@ -100,9 +102,13 @@ environment:
 
 This serves `/api/x402/supported`, `/api/x402/verify`, and `/api/x402/settle`.
 Portal payments intentionally support only Sui mainnet/testnet USDC through the
-gasless stablecoin address-balance flow. Route-level payment enforcement is
-configured separately by the tunnel with `portal expose --x402-pay-to`; relay
-`X402_PAY_TO` is reserved for relay-owned resources.
+gasless stablecoin address-balance flow.
+
+Tunnel paid routes do not use these relay settings. Route-level payment
+enforcement is configured separately by the tunnel with
+`portal expose --x402-pay-to` and optional `--x402-testnet`; relay
+`X402_PAY_TO` and `X402_TESTNET` are reserved for relay-owned control-plane
+resources.
 
 ## Connecting Your Tunnel
 

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -132,7 +132,7 @@ export function Header({
               )}
               {x402 && (
                 <span className="inline-flex h-6 items-center rounded-full bg-secondary px-2.5 text-xs font-semibold text-text-muted ring-1 ring-border/70">
-                  x402 {x402NetworkLabel(x402)}
+                  relay x402 {x402NetworkLabel(x402)}
                 </span>
               )}
             </div>

--- a/sdk/expose.go
+++ b/sdk/expose.go
@@ -57,6 +57,7 @@ type ExposeConfig struct {
 	MaxActiveRelays int
 	Metadata        types.LeaseMetadata
 	X402PayTo       string
+	X402Testnet     bool
 }
 
 func (cfg ExposeConfig) snapshot() ExposeConfig {
@@ -153,6 +154,7 @@ func Expose(ctx context.Context, cfg ExposeConfig) (*Exposure, error) {
 	runtimeCfg.MultiHop = append([]string(nil), multiHop...)
 	runtimeCfg.Metadata = cfg.Metadata.Copy()
 	runtimeCfg.X402PayTo = x402PayTo
+	runtimeCfg.X402Testnet = cfg.X402Testnet
 
 	exposureCtx, cancel := context.WithCancel(ctx)
 	exposure := &Exposure{
@@ -525,7 +527,7 @@ func (e *Exposure) WaitDatagramReady(ctx context.Context) ([]string, error) {
 // RunHTTPRoutes serves path-routed HTTP upstreams through the exposure.
 func (e *Exposure) RunHTTPRoutes(ctx context.Context, routes []HTTPRouteConfig, localAddr string) error {
 	cfg := e.Config()
-	handler, err := NewHTTPRoutes(routes, cfg.X402PayTo)
+	handler, err := NewHTTPRoutes(routes, cfg.X402PayTo, cfg.X402Testnet)
 	if err != nil {
 		return err
 	}

--- a/sdk/http.go
+++ b/sdk/http.go
@@ -142,7 +142,7 @@ type HTTPRoutes struct {
 }
 
 // NewHTTPRoutes creates a handler for path-routed upstreams and the shared x402 prepare endpoint.
-func NewHTTPRoutes(routeConfigs []HTTPRouteConfig, x402PayTo string) (*HTTPRoutes, error) {
+func NewHTTPRoutes(routeConfigs []HTTPRouteConfig, x402PayTo string, x402Testnet bool) (*HTTPRoutes, error) {
 	if len(routeConfigs) == 0 {
 		return nil, errors.New("at least one http route is required")
 	}
@@ -151,7 +151,7 @@ func NewHTTPRoutes(routeConfigs []HTTPRouteConfig, x402PayTo string) (*HTTPRoute
 	routes := make([]*httpRoute, 0, len(routeConfigs))
 	seen := make(map[string]struct{}, len(routeConfigs))
 	for _, routeConfig := range routeConfigs {
-		route, err := newHTTPRoute(routeConfig, x402PayTo)
+		route, err := newHTTPRoute(routeConfig, x402PayTo, x402Testnet)
 		if err != nil {
 			return nil, err
 		}
@@ -240,7 +240,7 @@ type httpRoute struct {
 	handler        http.Handler
 }
 
-func newHTTPRoute(routeConfig HTTPRouteConfig, x402PayTo string) (*httpRoute, error) {
+func newHTTPRoute(routeConfig HTTPRouteConfig, x402PayTo string, x402Testnet bool) (*httpRoute, error) {
 	prefix := strings.TrimSpace(routeConfig.Prefix)
 	if prefix == "" {
 		return nil, errors.New("http route prefix is required")
@@ -298,8 +298,9 @@ func newHTTPRoute(routeConfig HTTPRouteConfig, x402PayTo string) (*httpRoute, er
 			methods[method] = struct{}{}
 		}
 		payment, err := x402.NewUSDCPayment(types.X402Payment{
-			PayTo:  x402PayTo,
-			Amount: amount,
+			Testnet: x402Testnet,
+			PayTo:   x402PayTo,
+			Amount:  amount,
 		})
 		if err != nil {
 			return nil, fmt.Errorf("http route %q x402 payment: %w", route.prefix, err)

--- a/sdk/http_test.go
+++ b/sdk/http_test.go
@@ -25,7 +25,7 @@ func TestHTTPRoutesUseLongestPrefix(t *testing.T) {
 	handler, err := NewHTTPRoutes([]HTTPRouteConfig{
 		{Prefix: "/", Upstream: rootServer.URL},
 		{Prefix: "/api", Upstream: apiServer.URL},
-	}, "")
+	}, "", false)
 	if err != nil {
 		t.Fatalf("NewHTTPRoutes() error = %v", err)
 	}
@@ -56,7 +56,7 @@ func TestHTTPRoutesRewriteResponseHeaders(t *testing.T) {
 
 	handler, err := NewHTTPRoutes([]HTTPRouteConfig{
 		{Prefix: "/app", Upstream: upstreamURL + "/base"},
-	}, "")
+	}, "", false)
 	if err != nil {
 		t.Fatalf("NewHTTPRoutes() error = %v", err)
 	}
@@ -80,7 +80,7 @@ func TestHTTPRoutesRejectDuplicateNormalizedPrefixes(t *testing.T) {
 	_, err := NewHTTPRoutes([]HTTPRouteConfig{
 		{Prefix: "/api", Upstream: "127.0.0.1:3001"},
 		{Prefix: "/api/", Upstream: "127.0.0.1:3002"},
-	}, "")
+	}, "", false)
 	if err == nil {
 		t.Fatal("NewHTTPRoutes() error = nil, want duplicate prefix error")
 	}

--- a/types/agent.go
+++ b/types/agent.go
@@ -19,6 +19,7 @@ type AgentTunnelStatus struct {
 	Metadata        LeaseMetadata      `json:"metadata,omitempty"`
 	MultiHop        []string           `json:"multi_hop,omitempty"`
 	X402PayTo       string             `json:"x402_pay_to,omitempty"`
+	X402Testnet     bool               `json:"x402_testnet,omitempty"`
 	HTTPRoutes      []AgentHTTPRoute   `json:"http_routes,omitempty"`
 	Relays          []AgentRelayStatus `json:"relays,omitempty"`
 }
@@ -52,6 +53,7 @@ type AgentTunnelRequest struct {
 	Discovery       *bool            `json:"discovery,omitempty"`
 	MaxActiveRelays int              `json:"max_active_relays,omitempty"`
 	X402PayTo       string           `json:"x402_pay_to,omitempty"`
+	X402Testnet     bool             `json:"x402_testnet,omitempty"`
 }
 
 type AgentRelayRequest struct {

--- a/types/x402.go
+++ b/types/x402.go
@@ -7,7 +7,7 @@ import (
 	facilitatortypes "github.com/gosuda/x402-facilitator/types"
 )
 
-// X402FacilitatorInfo describes relay-level x402 facilitator settings exposed by the API.
+// X402FacilitatorInfo describes relay-owned x402 control-plane facilitator settings exposed by the API.
 type X402FacilitatorInfo struct {
 	Enabled      bool   `json:"enabled"`
 	URL          string `json:"url,omitempty"`


### PR DESCRIPTION
- Updated README and documentation to reflect the new `--x402-testnet` flag for using Sui testnet.
- Enhanced tunnel configuration to include `x402_testnet` boolean.
- Modified dashboard and CLI to support x402 testnet settings.
- Adjusted payment handling in SDK and HTTP routes to accommodate testnet configurations.
- Updated API references to clarify the distinction between relay-owned and tunnel-owned x402 facilitator settings.