### PR TITLE
ci: remove govulncheck from verification

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,4 +39,3 @@ jobs:
           make vet
           make lint
           make test
-          make vuln

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,7 +27,7 @@ Architecture, product behavior, and design rationale belong in `docs/architectur
 
 ## Verification
 
-- CI commands: `make vet`, `make lint`, `make test`, `make vuln`.
+- CI commands: `make vet`, `make lint`, `make test`.
 - `make tidy` is local maintenance, not a CI requirement.
 - Run tests only when explicitly requested.
 - If verification seems necessary, ask before running it.

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help install fmt vet lint lint-auto test vuln tidy all run build build-frontend build-docs build-tunnel build-server clean load-test
+.PHONY: help install fmt vet lint lint-auto test tidy all run build build-frontend build-docs build-tunnel build-server clean load-test
 
 .DEFAULT_GOAL := help
 
@@ -6,7 +6,6 @@ GO_PACKAGES := ./cmd/... ./portal/... ./sdk/... ./types/...
 GO_TOOLCHAIN_VERSION := $(shell awk '/^go / { print "go" $$2; exit }' go.mod)
 GOIMPORTS_VERSION := v0.41.0
 GOLANGCI_LINT_VERSION := v2.11.1
-GOVULNCHECK_VERSION := v1.1.4
 
 export GOTOOLCHAIN := $(GO_TOOLCHAIN_VERSION)
 
@@ -27,7 +26,6 @@ help:
 install:
 	go install golang.org/x/tools/cmd/goimports@$(GOIMPORTS_VERSION)
 	go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION)
-	go install golang.org/x/vuln/cmd/govulncheck@$(GOVULNCHECK_VERSION)
 
 fmt:
 	gofmt -w .
@@ -47,15 +45,12 @@ lint-auto:
 test:
 	go test -v -coverprofile=coverage.out $(GO_PACKAGES)
 
-vuln:
-	govulncheck $(GO_PACKAGES)
-
 tidy:
 	go get -u ./...
 	go mod tidy
 	go mod verify
 
-all: fmt vet lint test vuln build
+all: fmt vet lint test build
 
 run:
 	./bin/relay-server


### PR DESCRIPTION
## Summary
- remove the blocking govulncheck step from GitHub Actions verification
- stop installing govulncheck and remove the Makefile vuln target
- remove vuln from the aggregate all target
- align AGENTS.md with the remaining CI commands: vet, lint, and test

## Rationale
Keep pull request verification focused on vet, lint, and the full test suite. Dependency and toolchain vulnerability remediation can be handled through explicit maintenance updates instead of blocking every pull request on the vulnerability database.

## Security impact
This change intentionally removes govulncheck coverage from CI and local Makefile targets. Vulnerability monitoring and remediation must therefore be handled separately through dependency maintenance and repository security tooling.

## Verification
- confirmed there are no remaining govulncheck, golang.org/x/vuln, GOVULNCHECK_VERSION, or make vuln references
- git diff --check passed
- static review confirmed the Makefile, CI workflow, and contributor instructions remain consistent
- both GitHub Actions Verify runs passed go vet, golangci-lint, and the full test suite
- all CodeQL checks passed
- tests were not run manually, following the repository instruction