### PR TITLE
feat(tunnel): serve local static sites and detect share links

### DIFF
--- a/cmd/portal-tunnel/README.md
+++ b/cmd/portal-tunnel/README.md
@@ -38,6 +38,16 @@ Default HTTPS stream for most local web apps:
 portal expose 3000 --name myapp
 ```
 
+Static site when you want to publish a local folder or a single HTML file
+without running a server. Pass a directory (served with `index.html`) or an HTML
+file (its folder is served with that file as the SPA/CSR entry). Unknown paths
+fall back to the entry file, and paths escaping the folder are refused:
+
+```text
+portal expose --serve ./site --name my-app
+portal expose --serve ./site/main.html --name my-app
+```
+
 Routed HTTP when one public URL should mount multiple local HTTP upstreams:
 
 ```text
@@ -100,6 +110,7 @@ Common `portal expose` flags:
 --thumbnail          Service thumbnail URL metadata
 --owner              Service owner metadata
 --hide               Hide service from relay listing screens
+--serve              Serve a local static site: a directory (served with index.html) or an HTML file (folder served with that file as SPA/CSR entry)
 --http-route         HTTP route mapping in PATH=UPSTREAM [METHOD[,METHOD...]:USDC_AMOUNT] form
 --x402-pay-to        Sui USDC payment recipient address for this tunnel
 --x402-testnet       Use Sui testnet for tunnel x402 payments
@@ -130,6 +141,10 @@ the Settings pane. Edit `http_routes`, `x402_pay_to`, `x402_testnet`, or
 ## Constraints
 
 - A positional `<target>` cannot be combined with `--http-route`.
+- `--serve` cannot be combined with a positional `<target>`, `--http-route`,
+  `--udp`, or `--tcp`. The `--serve` entry file must exist. Path traversal
+  (`..`) is refused, but a symlink inside the folder that points outside it is
+  still followed, so only serve folders you trust.
 - `--http-route` cannot be combined with `--udp`.
 - Route payment amounts are USDC values such as `0.01`, are part of
   `--http-route`, and require `--x402-pay-to`; add `--x402-testnet` for Sui

--- a/cmd/portal-tunnel/main.go
+++ b/cmd/portal-tunnel/main.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"path/filepath"
 	"strings"
 	"sync"
 	"text/tabwriter"
@@ -63,6 +64,7 @@ type exposeFlags struct {
 	x402Testnet     bool
 	targetAddr      string
 	httpRoutes      []string
+	serve           string
 	udp             bool
 	udpAddr         string
 	tcp             bool
@@ -92,6 +94,7 @@ func runExposeCommand(args []string) error {
 	utils.StringFlag(fs, &flags.x402PayTo, "x402-pay-to", "", "Sui USDC payment recipient address for this tunnel")
 	utils.BoolFlag(fs, &flags.x402Testnet, "x402-testnet", false, "Use Sui testnet for tunnel x402 payments; default is Sui mainnet")
 	utils.RepeatedStringFlag(fs, &flags.httpRoutes, "http-route", "HTTP route mapping in PATH=UPSTREAM [METHOD[,METHOD...]:USDC_AMOUNT] form; repeat to aggregate multiple local HTTP services behind one public URL")
+	utils.StringFlag(fs, &flags.serve, "serve", "", "Serve a local static site: pass a directory (served with index.html) or an HTML file (its folder is served with that file as the SPA/CSR entry). Unknown paths fall back to the entry file")
 	utils.BoolFlagEnv(fs, &flags.udp, "udp", false, "Enable public UDP relay in addition to the default TCP relay", "UDP_ENABLED")
 	utils.StringFlagEnv(fs, &flags.udpAddr, "udp-addr", "", "Local UDP target address for relayed datagrams (host:port or port only); defaults to the target when --udp is enabled", "UDP_ADDR")
 	utils.BoolFlagEnv(fs, &flags.tcp, "tcp", false, "Request a dedicated TCP port on the relay for raw TCP services (no TLS; e.g., Minecraft, game servers)", "TCP_ENABLED")
@@ -113,10 +116,23 @@ func runExposeCommand(args []string) error {
 		return err
 	}
 	httpRouteInputs := append([]string(nil), flags.httpRoutes...)
+	serve := strings.TrimSpace(flags.serve)
 	switch {
-	case flags.targetAddr == "" && len(httpRouteInputs) == 0:
+	case serve != "" && flags.targetAddr != "":
 		printExposeUsage(os.Stderr)
-		return errors.New("target or at least one --http-route is required")
+		return errors.New("target cannot be combined with --serve")
+	case serve != "" && len(httpRouteInputs) > 0:
+		printExposeUsage(os.Stderr)
+		return errors.New("--serve cannot be combined with --http-route")
+	case serve != "" && flags.udp:
+		printExposeUsage(os.Stderr)
+		return errors.New("--serve cannot be combined with --udp")
+	case serve != "" && flags.tcp:
+		printExposeUsage(os.Stderr)
+		return errors.New("--serve cannot be combined with --tcp")
+	case serve == "" && flags.targetAddr == "" && len(httpRouteInputs) == 0:
+		printExposeUsage(os.Stderr)
+		return errors.New("target, --serve, or at least one --http-route is required")
 	case flags.targetAddr != "" && len(flags.httpRoutes) > 0:
 		printExposeUsage(os.Stderr)
 		return errors.New("target cannot be combined with --http-route")
@@ -125,7 +141,19 @@ func runExposeCommand(args []string) error {
 		return errors.New("--udp cannot be combined with --http-route")
 	}
 
-	httpRoutes := make([]sdk.HTTPRouteConfig, 0, len(httpRouteInputs))
+	httpRoutes := make([]sdk.HTTPRouteConfig, 0, len(httpRouteInputs)+1)
+	if serve != "" {
+		root, index, err := resolveServeDir(serve)
+		if err != nil {
+			printExposeUsage(os.Stderr)
+			return err
+		}
+		httpRoutes = append(httpRoutes, sdk.HTTPRouteConfig{
+			Prefix:      "/",
+			StaticRoot:  root,
+			StaticIndex: index,
+		})
+	}
 	for _, raw := range httpRouteInputs {
 		fields := strings.Fields(raw)
 		if len(fields) == 0 || len(fields) > 2 {
@@ -210,11 +238,38 @@ func runExposeCommand(args []string) error {
 	if err != nil {
 		return fmt.Errorf("failed to start relays: %w", err)
 	}
-	if len(httpRouteInputs) > 0 {
+	if len(httpRoutes) > 0 {
 		defer exposure.Close()
 		return exposure.RunHTTPRoutes(ctx, httpRoutes, "")
 	}
 	return sdk.ProxyExposure(ctx, exposure)
+}
+
+// resolveServeDir turns a --serve path into a static root directory and its SPA
+// entry file. A directory serves index.html; an HTML file serves its parent
+// directory with that file as the entry. The entry file must exist.
+func resolveServeDir(input string) (root string, index string, err error) {
+	abs, err := filepath.Abs(strings.TrimSpace(input))
+	if err != nil {
+		return "", "", fmt.Errorf("--serve %q: %w", input, err)
+	}
+	info, err := os.Stat(abs)
+	if err != nil {
+		return "", "", fmt.Errorf("--serve %q: %w", input, err)
+	}
+	if info.IsDir() {
+		root, index = abs, "index.html"
+	} else {
+		root, index = filepath.Dir(abs), filepath.Base(abs)
+	}
+	indexInfo, err := os.Stat(filepath.Join(root, index))
+	if err != nil {
+		return "", "", fmt.Errorf("--serve %q: entry file %q not found: %w", input, index, err)
+	}
+	if indexInfo.IsDir() {
+		return "", "", fmt.Errorf("--serve %q: entry %q is a directory", input, index)
+	}
+	return root, index, nil
 }
 
 func parseHTTPRoutePayment(value string) ([]string, string, error) {
@@ -376,11 +431,14 @@ func printExposeUsage(w io.Writer) {
 	utils.WriteCommandUsage(w,
 		[]string{
 			"portal expose [flags] <target>",
+			"portal expose [flags] --serve <dir|file.html>",
 			"portal expose [flags] --http-route \"PATH=UPSTREAM [METHOD[,METHOD...]:USDC_AMOUNT]\" [...]",
 		},
 		[]string{
 			"portal expose 3000",
 			"portal expose localhost:8080 --name my-app",
+			"portal expose --serve ./site --name my-app",
+			"portal expose --serve ./site/main.html --name my-app",
 			"portal expose --http-route /api=http://127.0.0.1:3001 --http-route /=http://127.0.0.1:5173 --name my-app",
 			"portal expose --http-route \"/paid=http://127.0.0.1:3001 GET:0.01\" --http-route /=http://127.0.0.1:5173 --x402-pay-to 0x...",
 			"portal expose 3000 --udp --udp-addr 127.0.0.1:5353",

--- a/cmd/portal-tunnel/main.go
+++ b/cmd/portal-tunnel/main.go
@@ -8,7 +8,6 @@ import (
 	"io"
 	"net/http"
 	"os"
-	"path/filepath"
 	"strings"
 	"sync"
 	"text/tabwriter"
@@ -143,10 +142,10 @@ func runExposeCommand(args []string) error {
 
 	httpRoutes := make([]sdk.HTTPRouteConfig, 0, len(httpRouteInputs)+1)
 	if serve != "" {
-		root, index, err := resolveServeDir(serve)
+		root, index, err := utils.ResolveStaticSite(serve)
 		if err != nil {
 			printExposeUsage(os.Stderr)
-			return err
+			return fmt.Errorf("--serve %q: %w", serve, err)
 		}
 		httpRoutes = append(httpRoutes, sdk.HTTPRouteConfig{
 			Prefix:      "/",
@@ -243,33 +242,6 @@ func runExposeCommand(args []string) error {
 		return exposure.RunHTTPRoutes(ctx, httpRoutes, "")
 	}
 	return sdk.ProxyExposure(ctx, exposure)
-}
-
-// resolveServeDir turns a --serve path into a static root directory and its SPA
-// entry file. A directory serves index.html; an HTML file serves its parent
-// directory with that file as the entry. The entry file must exist.
-func resolveServeDir(input string) (root string, index string, err error) {
-	abs, err := filepath.Abs(strings.TrimSpace(input))
-	if err != nil {
-		return "", "", fmt.Errorf("--serve %q: %w", input, err)
-	}
-	info, err := os.Stat(abs)
-	if err != nil {
-		return "", "", fmt.Errorf("--serve %q: %w", input, err)
-	}
-	if info.IsDir() {
-		root, index = abs, "index.html"
-	} else {
-		root, index = filepath.Dir(abs), filepath.Base(abs)
-	}
-	indexInfo, err := os.Stat(filepath.Join(root, index))
-	if err != nil {
-		return "", "", fmt.Errorf("--serve %q: entry file %q not found: %w", input, index, err)
-	}
-	if indexInfo.IsDir() {
-		return "", "", fmt.Errorf("--serve %q: entry %q is a directory", input, index)
-	}
-	return root, index, nil
 }
 
 func parseHTTPRoutePayment(value string) ([]string, string, error) {

--- a/docs/src/lib/components/landing/TunnelCommandForm.svelte
+++ b/docs/src/lib/components/landing/TunnelCommandForm.svelte
@@ -6,11 +6,15 @@
 		RELAY_ORIGIN,
 		type TunnelCommandOS
 	} from '$lib/tunnel-command';
-	import { buildDefaultExposeName, resolveExposeName } from '$lib/expose-name';
+	import { buildDefaultExposeName } from '$lib/expose-name';
+	import { classifyShareInput, type ShareKind } from '$lib/share-link';
 
-	const DEFAULT_HOST = '3000';
+	const SHARE_KIND_LABEL: Record<ShareKind, string> = { url: 'URL', file: 'File', port: 'Port' };
+	const SHARE_PLACEHOLDER = 'file:///Users/me/site/index.html or 3000';
 
-	let target = $state('3000');
+	// Empty by default so the field reads as "paste a link here" instead of
+	// pre-committing the user to a local port.
+	let target = $state('');
 	let os: TunnelCommandOS = $state('unix');
 	let name = $state('');
 	let nameSeed = $state('');
@@ -20,49 +24,35 @@
 		nameSeed = crypto.randomUUID();
 	});
 
-	const generatedName = $derived(buildDefaultExposeName(target, nameSeed));
+	const share = $derived(classifyShareInput(target));
+	const generatedName = $derived(buildDefaultExposeName(share.seedTarget, nameSeed));
 	const effectiveName = $derived(name.trim() || generatedName);
 
-	const installBlock = $derived.by(() => {
-		const cmd = buildTunnelDisplayCommand({
+	const commandLines = $derived.by(() =>
+		buildTunnelDisplayCommand({
 			currentOrigin: RELAY_ORIGIN,
-			target,
+			target: share.target,
 			name: effectiveName,
 			nameSeed,
 			relayUrls: [RELAY_ORIGIN],
 			discovery: true,
 			thumbnailURL: '',
-			os
-		});
-		const lines = cmd.split('\n');
-		// Install is first line(s), expose is the rest
-		if (os === 'windows') {
-			// Windows: first two lines are install
-			return lines.slice(0, 2).join('\n');
-		}
-		return lines[0] ?? '';
-	});
+			os,
+			shareKind: share.kind,
+			servePath: share.path
+		}).split('\n')
+	);
 
-	const runBlock = $derived.by(() => {
-		const cmd = buildTunnelDisplayCommand({
-			currentOrigin: RELAY_ORIGIN,
-			target,
-			name: effectiveName,
-			nameSeed,
-			relayUrls: [RELAY_ORIGIN],
-			discovery: true,
-			thumbnailURL: '',
-			os
-		});
-		const lines = cmd.split('\n');
-		if (os === 'windows') {
-			return lines.slice(2).join('\n');
-		}
-		return lines.slice(1).join('\n');
-	});
+	// Install is the first line(s); the expose command is the rest.
+	const installBlock = $derived(
+		os === 'windows' ? commandLines.slice(0, 2).join('\n') : (commandLines[0] ?? '')
+	);
+	const runBlock = $derived(
+		os === 'windows' ? commandLines.slice(2).join('\n') : commandLines.slice(1).join('\n')
+	);
 
 	const previewURL = $derived(
-		buildTunnelPreviewURL(RELAY_ORIGIN, effectiveName, target, nameSeed)
+		buildTunnelPreviewURL(RELAY_ORIGIN, effectiveName, share.seedTarget, nameSeed)
 	);
 
 	function handleCopy() {
@@ -123,16 +113,23 @@
 			</div>
 
 			<div class="space-y-5">
-				<!-- 1. Start your local app -->
+				<!-- 1. Paste what you want to share -->
 				<div class="space-y-2">
 					<div class="space-y-1.5">
 						<p class="text-[13px] font-semibold tracking-[0.04em] text-slate-100 sm:text-sm">
-							1. Start your local app
-							<span class="ml-1 normal-case tracking-normal text-slate-400">
-								(e.g.
-								<span class="mx-1 font-mono text-slate-200">localhost:3000</span>
-								)
-							</span>
+							1. Paste what you want to share
+						</p>
+						<p class="text-[12px] leading-5 text-slate-400">
+							A local port such as
+							<span class="mx-1 font-mono text-slate-200">3000</span>, a running URL
+							such as
+							<span class="mx-1 font-mono text-slate-200">http://localhost:3000</span>,
+							or a file path such as
+							<span class="mx-1 font-mono text-slate-200"
+								>file:///Users/me/site/index.html</span
+							>
+							— file paths are served as a static site straight from that folder, so
+							nothing needs to be running locally.
 						</p>
 					</div>
 				</div>
@@ -174,23 +171,32 @@
 						</div>
 					</div>
 
-					<!-- Port + Name controls -->
-					<div class="flex flex-wrap items-center gap-x-4 gap-y-2 sm:flex-nowrap">
-						<div class="flex shrink-0 items-center gap-2">
+					<!-- Share + Name controls -->
+					<div class="space-y-2">
+						<div class="flex min-w-0 items-center gap-2">
 							<span
 								class="shrink-0 text-[9px] font-semibold uppercase tracking-[0.16em] text-slate-500"
 							>
-								Port
+								Share
 							</span>
 							<input
 								type="text"
 								bind:value={target}
-								placeholder={DEFAULT_HOST}
-								aria-label="Local port or address"
-								class="h-auto w-[76px] border-0 bg-transparent px-0 py-0 font-mono text-[13px] text-slate-200 shadow-none outline-none placeholder:text-slate-600"
+								placeholder={SHARE_PLACEHOLDER}
+								aria-label="Link, file path, or local port to share"
+								class="h-auto min-w-0 flex-1 border-0 bg-transparent px-0 py-0 font-mono text-[13px] text-slate-200 shadow-none outline-none placeholder:text-slate-600"
 							/>
+							{#if target.trim() !== ''}
+								<span
+									class="shrink-0 rounded px-1.5 py-0.5 text-[9px] font-semibold uppercase tracking-[0.12em] text-slate-400"
+									style="background: rgba(255,255,255,0.06);"
+									title="Detected share type"
+								>
+									{SHARE_KIND_LABEL[share.kind]}
+								</span>
+							{/if}
 						</div>
-						<div class="ml-auto flex min-w-0 items-center justify-end gap-2 sm:w-88">
+						<div class="flex min-w-0 items-center gap-2">
 							<span
 								class="shrink-0 text-[9px] font-semibold uppercase tracking-[0.16em] text-slate-500"
 							>

--- a/docs/src/lib/share-link.ts
+++ b/docs/src/lib/share-link.ts
@@ -1,0 +1,70 @@
+/**
+ * Classifies what a user pasted into the quick-start form so the generated
+ * command matches their intent:
+ *
+ * - `url`  — an `http(s)://` link: expose the host/port it points at.
+ * - `file` — a `file://` URL, a Windows path, or an absolute POSIX path: serve
+ *            the local static site with `portal expose --serve <path>`.
+ * - `port` — a bare port, `host:port`, or anything else: current behavior.
+ */
+export type ShareKind = 'url' | 'file' | 'port';
+
+export interface ShareInput {
+	kind: ShareKind;
+	/** Positional `portal expose <target>` value for `url` / `port` kinds. */
+	target: string;
+	/** Local filesystem path passed to `--serve` for the `file` kind. */
+	path: string;
+	/** Stable string used to seed auto-generated names. */
+	seedTarget: string;
+}
+
+const WINDOWS_PATH = /^[A-Za-z]:[\\/]/;
+const UNC_PATH = /^\\\\/;
+
+export function classifyShareInput(raw: string): ShareInput {
+	const trimmed = raw.trim();
+	if (trimmed === '') {
+		return { kind: 'port', target: '', path: '', seedTarget: '' };
+	}
+
+	if (/^https?:\/\//i.test(trimmed)) {
+		const target = urlToExposeTarget(trimmed);
+		return { kind: 'url', target, path: '', seedTarget: target || trimmed };
+	}
+
+	if (/^file:\/\//i.test(trimmed)) {
+		const path = fileURLToPath(trimmed);
+		return { kind: 'file', target: '', path, seedTarget: path || trimmed };
+	}
+
+	if (WINDOWS_PATH.test(trimmed) || UNC_PATH.test(trimmed) || trimmed.startsWith('/')) {
+		return { kind: 'file', target: '', path: trimmed, seedTarget: trimmed };
+	}
+
+	return { kind: 'port', target: trimmed, path: '', seedTarget: trimmed };
+}
+
+function urlToExposeTarget(raw: string): string {
+	try {
+		const parsed = new URL(raw);
+		if (parsed.hostname === '') return '';
+		return parsed.port ? `${parsed.hostname}:${parsed.port}` : parsed.hostname;
+	} catch {
+		return '';
+	}
+}
+
+function fileURLToPath(raw: string): string {
+	try {
+		const parsed = new URL(raw);
+		let path = decodeURIComponent(parsed.pathname);
+		// file:///C:/dir/main.html → /C:/dir/main.html → C:/dir/main.html
+		if (/^\/[A-Za-z]:[\\/]/.test(path)) {
+			path = path.slice(1);
+		}
+		return path;
+	} catch {
+		return raw.replace(/^file:\/\//i, '');
+	}
+}

--- a/docs/src/lib/tunnel-command.ts
+++ b/docs/src/lib/tunnel-command.ts
@@ -1,4 +1,5 @@
 import { resolveExposeName } from './expose-name';
+import type { ShareKind } from './share-link';
 
 /** Hardcoded relay origin for the static docs site */
 export const RELAY_ORIGIN = 'https://portal.suda.me';
@@ -16,6 +17,10 @@ export interface TunnelCommandOptions {
 	enableUDP?: boolean;
 	udpPort?: string;
 	os: TunnelCommandOS;
+	/** How the share input was classified; defaults to 'port'. */
+	shareKind?: ShareKind;
+	/** Local path passed to `--serve` when shareKind is 'file'. */
+	servePath?: string;
 }
 
 export function buildTunnelDisplayCommand(opts: TunnelCommandOptions): string {
@@ -44,15 +49,22 @@ function buildTunnelCommandParts({
 	relayUrls,
 	target,
 	thumbnailURL,
-	udpPort = ''
+	udpPort = '',
+	shareKind = 'port',
+	servePath = ''
 }: TunnelCommandOptions): {
 	installLine: string;
 	exposeHead: string;
 	exposeOptions: string[];
 } {
+	const isFile = shareKind === 'file';
 	const targetValue = target.trim() === '' ? '3000' : target.trim();
-	const nameValue = resolveExposeName(name, targetValue, nameSeed);
+	const nameSeedTarget = isFile ? servePath : targetValue;
+	const nameValue = resolveExposeName(name, nameSeedTarget, nameSeed);
 	const relayURLValue = relayUrls.length > 0 ? relayUrls.join(',') : currentOrigin;
+	const leadingArgs = isFile
+		? ['--serve', formatToken(servePath, os)]
+		: [formatToken(targetValue, os)];
 
 	// Inlined install paths — no apiPaths dependency
 	const installScriptURL = new URL('/api/install.sh', currentOrigin).toString();
@@ -86,7 +98,7 @@ function buildTunnelCommandParts({
 				`irm ${formatToken(installPowerShellURL, os)} | iex`
 			].join('\n'),
 			exposeHead: 'portal expose',
-			exposeOptions: [formatToken(targetValue, os), ...exposeArgs]
+			exposeOptions: [...leadingArgs, ...exposeArgs]
 		};
 	}
 
@@ -94,7 +106,7 @@ function buildTunnelCommandParts({
 	return {
 		installLine: `curl ${curlFlags} ${formatToken(installScriptURL, os)} | bash`,
 		exposeHead: 'portal expose',
-		exposeOptions: [formatToken(targetValue, os), ...exposeArgs]
+		exposeOptions: [...leadingArgs, ...exposeArgs]
 	};
 }
 

--- a/frontend/src/components/TunnelCommandForm.tsx
+++ b/frontend/src/components/TunnelCommandForm.tsx
@@ -21,6 +21,15 @@ import {
   readCurrentOrigin,
   useTunnelCommand,
 } from "@/hooks/useTunnelCommand";
+import type { ShareKind } from "@/lib/shareLink";
+
+const SHARE_KIND_LABEL: Record<ShareKind, string> = {
+  url: "URL",
+  file: "File",
+  port: "Port",
+};
+
+const SHARE_PLACEHOLDER = "file:///Users/me/site/index.html or 3000";
 
 interface TunnelCommandFormProps {
   className?: string;
@@ -58,6 +67,7 @@ function HeroTunnelCommandForm({
     setOs,
     generatedName,
     effectiveName,
+    shareKind,
     installBlock,
     runBlock,
     handleCopy,
@@ -159,6 +169,10 @@ function HeroTunnelCommandForm({
     "shrink-0 text-[9px] font-semibold uppercase tracking-normal",
     isTerminal ? "text-slate-500" : "text-text-muted"
   );
+  const heroExampleClass = cn(
+    "mx-1 font-mono",
+    isTerminal ? "text-slate-200" : "text-foreground"
+  );
   const heroControlInputClass = cn(
     "h-auto border-0 bg-transparent px-0 py-0 text-[13px] shadow-none focus-visible:ring-0",
     isTerminal
@@ -176,24 +190,23 @@ function HeroTunnelCommandForm({
       <div className="space-y-2">
         <div className="space-y-1.5">
           <p className={heroSectionLabelClass}>
-            1. Start your local app
-            <span
-              className={cn(
-                "ml-1 normal-case tracking-normal",
-                isTerminal ? "text-slate-400" : "text-text-muted"
-              )}
-            >
-              (e.g.
-              <span
-                className={cn(
-                  "mx-1 font-mono",
-                  isTerminal ? "text-slate-200" : "text-foreground"
-                )}
-              >
-                localhost:3000
-              </span>
-              )
+            1. Paste what you want to share
+          </p>
+          <p
+            className={cn(
+              "text-[12px] leading-5",
+              isTerminal ? "text-slate-400" : "text-text-muted"
+            )}
+          >
+            A local port such as
+            <span className={heroExampleClass}>3000</span>, a running URL such as
+            <span className={heroExampleClass}>http://localhost:3000</span>, or a
+            file path such as
+            <span className={heroExampleClass}>
+              file:///Users/me/site/index.html
             </span>
+            — file paths are served as a static site straight from that folder,
+            so nothing needs to be running locally.
           </p>
         </div>
       </div>
@@ -218,19 +231,32 @@ function HeroTunnelCommandForm({
             </button>
           </div>
         </div>
-        <div className="flex flex-wrap items-center gap-x-4 gap-y-2 sm:flex-nowrap">
-          <div className="flex shrink-0 items-center gap-2">
-            <span className={heroControlLabelClass}>Port</span>
+        <div className="space-y-2">
+          <div className="flex min-w-0 items-center gap-2">
+            <span className={heroControlLabelClass}>Share</span>
             <Input
               type="text"
               value={target}
               onChange={(event) => setTarget(event.target.value)}
-              placeholder={DEFAULT_HOST}
-              aria-label="Local port or address"
-              className={cn(heroControlInputClass, "w-20 font-mono")}
+              placeholder={SHARE_PLACEHOLDER}
+              aria-label="Link, file path, or local port to share"
+              className={cn(heroControlInputClass, "min-w-0 flex-1 font-mono")}
             />
+            {target.trim() !== "" && (
+              <span
+                className={cn(
+                  "shrink-0 rounded px-1.5 py-0.5 text-[9px] font-semibold uppercase tracking-normal",
+                  isTerminal
+                    ? "bg-white/8 text-slate-400"
+                    : "bg-muted text-text-muted"
+                )}
+                title="Detected share type"
+              >
+                {SHARE_KIND_LABEL[shareKind]}
+              </span>
+            )}
           </div>
-          <div className="ml-auto flex min-w-0 items-center justify-end gap-2 sm:w-88">
+          <div className="flex min-w-0 items-center gap-2">
             <span className={heroControlLabelClass}>Name</span>
             <Input
               type="text"
@@ -367,6 +393,7 @@ function FullTunnelCommandForm({
     os,
     setOs,
     generatedName,
+    shareKind,
     installBlock,
     runBlock,
     handleCopy,
@@ -463,25 +490,41 @@ function FullTunnelCommandForm({
   return (
     <div className={cn("space-y-4 py-1", className)}>
       <div className="space-y-2">
-        <label
-          htmlFor={`${inputId}-host`}
-          className={sectionLabelClass}
-        >
-          Host
-        </label>
+        <div className="flex items-center gap-2">
+          <label htmlFor={`${inputId}-host`} className={sectionLabelClass}>
+            Share
+          </label>
+          {target.trim() !== "" && (
+            <span
+              className={cn(
+                "rounded px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-normal",
+                isTerminal
+                  ? "bg-white/8 text-slate-400"
+                  : "bg-muted text-text-muted"
+              )}
+              title="Detected share type"
+            >
+              {SHARE_KIND_LABEL[shareKind]}
+            </span>
+          )}
+        </div>
         <div className={inlineFieldClass}>
-          <span className={inlinePrefixClass}>HOST=</span>
+          <span className={inlinePrefixClass}>SHARE=</span>
           <Input
             id={`${inputId}-host`}
             type="text"
             value={target}
             onChange={(event) => setTarget(event.target.value)}
-            placeholder={DEFAULT_HOST}
+            placeholder={SHARE_PLACEHOLDER}
+            aria-label="Local port, URL, or file path to share"
             className={inlineInputClass}
           />
         </div>
         <p className={helpTextClass}>
-          The hostname or IP:Port where your service is running
+          Paste what you want to share: a local port (3000), a running URL
+          (http://localhost:3000), or a file path
+          (file:///Users/me/site/index.html). File paths are served as a static
+          site from that folder, so nothing needs to be running locally.
         </p>
       </div>
 

--- a/frontend/src/hooks/useTunnelCommand.ts
+++ b/frontend/src/hooks/useTunnelCommand.ts
@@ -3,6 +3,7 @@ import {
   buildDefaultExposeName,
   normalizeExposeName,
 } from "@/lib/exposeName";
+import { classifyShareInput } from "@/lib/shareLink";
 import {
   buildTunnelCommand,
   buildTunnelDisplayCommand,
@@ -68,20 +69,26 @@ export function useTunnelCommand(extras: TunnelCommandExtras = {}) {
   const currentOrigin = useMemo(() => readCurrentOrigin(), []);
   const [nameSeed] = useState(readTunnelNameSeed);
 
-  const [target, setTarget] = useState(DEFAULT_HOST);
+  // Empty by default so the field reads as "paste a link here" instead of
+  // pre-committing the user to a local port.
+  const [target, setTarget] = useState("");
   const [name, setName] = useState("");
   const [nameShuffleKey, setNameShuffleKey] = useState("default");
   const [copied, setCopied] = useState(false);
   const [os, setOs] = useState<TunnelCommandOS>("unix");
 
   const resolvedNameSeed = `${nameSeed}:${nameShuffleKey}`;
-  const generatedName = buildDefaultExposeName(target, resolvedNameSeed);
+  const share = useMemo(() => classifyShareInput(target), [target]);
+  const generatedName = buildDefaultExposeName(
+    share.seedTarget,
+    resolvedNameSeed
+  );
   const normalizedName = normalizeExposeName(name);
   const effectiveName = normalizedName === "" ? generatedName : normalizedName;
   const commandOptions = useMemo(
     () => ({
       currentOrigin,
-      target,
+      target: share.target,
       name: effectiveName,
       nameSeed,
       relayUrls: extras.relayUrls ?? [currentOrigin],
@@ -90,6 +97,8 @@ export function useTunnelCommand(extras: TunnelCommandExtras = {}) {
       enableUDP: extras.enableUDP ?? false,
       udpPort: extras.udpPort ?? "",
       os,
+      shareKind: share.kind,
+      servePath: share.path,
     }),
     [
       currentOrigin,
@@ -101,7 +110,9 @@ export function useTunnelCommand(extras: TunnelCommandExtras = {}) {
       extras.udpPort,
       nameSeed,
       os,
-      target,
+      share.kind,
+      share.path,
+      share.target,
     ]
   );
   const copyCommand = useMemo(
@@ -168,6 +179,7 @@ export function useTunnelCommand(extras: TunnelCommandExtras = {}) {
     setOs,
     generatedName,
     effectiveName,
+    shareKind: share.kind,
     installBlock,
     runBlock,
     handleCopy,

--- a/frontend/src/lib/shareLink.test.ts
+++ b/frontend/src/lib/shareLink.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+
+import { classifyShareInput } from "@/lib/shareLink";
+
+describe("classifyShareInput", () => {
+  it("treats bare ports and host:port as port shares", () => {
+    expect(classifyShareInput("3000")).toMatchObject({
+      kind: "port",
+      target: "3000",
+    });
+    expect(classifyShareInput("localhost:8080")).toMatchObject({
+      kind: "port",
+      target: "localhost:8080",
+    });
+  });
+
+  it("extracts host:port from http(s) URLs", () => {
+    expect(classifyShareInput("http://localhost:3000/x")).toMatchObject({
+      kind: "url",
+      target: "localhost:3000",
+    });
+    expect(classifyShareInput("https://example.com")).toMatchObject({
+      kind: "url",
+      target: "example.com",
+    });
+  });
+
+  it("resolves file:// URLs to filesystem paths", () => {
+    expect(classifyShareInput("file:///Users/me/site/main.html")).toMatchObject({
+      kind: "file",
+      path: "/Users/me/site/main.html",
+    });
+    expect(
+      classifyShareInput("file:///C:/Users/me/site/main.html")
+    ).toMatchObject({
+      kind: "file",
+      path: "C:/Users/me/site/main.html",
+    });
+  });
+
+  it("treats Windows, UNC, and absolute POSIX paths as file shares", () => {
+    expect(classifyShareInput("C:\\Users\\me\\site\\main.html")).toMatchObject({
+      kind: "file",
+      path: "C:\\Users\\me\\site\\main.html",
+    });
+    expect(classifyShareInput("\\\\host\\share\\index.html")).toMatchObject({
+      kind: "file",
+      path: "\\\\host\\share\\index.html",
+    });
+    expect(classifyShareInput("/Users/me/site")).toMatchObject({
+      kind: "file",
+      path: "/Users/me/site",
+    });
+  });
+
+  it("treats empty input as a port share", () => {
+    expect(classifyShareInput("   ")).toMatchObject({ kind: "port", target: "" });
+  });
+});

--- a/frontend/src/lib/shareLink.ts
+++ b/frontend/src/lib/shareLink.ts
@@ -1,0 +1,72 @@
+/**
+ * Classifies what a user pasted into the quick-start form so the generated
+ * command matches their intent:
+ *
+ * - `url`  — an `http(s)://` link: expose the host/port it points at.
+ * - `file` — a `file://` URL, a Windows path, or an absolute POSIX path: serve
+ *            the local static site with `portal expose --serve <path>`.
+ * - `port` — a bare port, `host:port`, or anything else: current behavior.
+ */
+export type ShareKind = "url" | "file" | "port";
+
+export interface ShareInput {
+  kind: ShareKind;
+  /** Positional `portal expose <target>` value for `url` / `port` kinds. */
+  target: string;
+  /** Local filesystem path passed to `--serve` for the `file` kind. */
+  path: string;
+  /** Stable string used to seed auto-generated names. */
+  seedTarget: string;
+}
+
+const WINDOWS_PATH = /^[A-Za-z]:[\\/]/;
+const UNC_PATH = /^\\\\/;
+
+export function classifyShareInput(raw: string): ShareInput {
+  const trimmed = raw.trim();
+  if (trimmed === "") {
+    return { kind: "port", target: "", path: "", seedTarget: "" };
+  }
+
+  if (/^https?:\/\//i.test(trimmed)) {
+    const target = urlToExposeTarget(trimmed);
+    return { kind: "url", target, path: "", seedTarget: target || trimmed };
+  }
+
+  if (/^file:\/\//i.test(trimmed)) {
+    const path = fileURLToPath(trimmed);
+    return { kind: "file", target: "", path, seedTarget: path || trimmed };
+  }
+
+  if (WINDOWS_PATH.test(trimmed) || UNC_PATH.test(trimmed) || trimmed.startsWith("/")) {
+    return { kind: "file", target: "", path: trimmed, seedTarget: trimmed };
+  }
+
+  return { kind: "port", target: trimmed, path: "", seedTarget: trimmed };
+}
+
+function urlToExposeTarget(raw: string): string {
+  try {
+    const parsed = new URL(raw);
+    if (parsed.hostname === "") {
+      return "";
+    }
+    return parsed.port ? `${parsed.hostname}:${parsed.port}` : parsed.hostname;
+  } catch {
+    return "";
+  }
+}
+
+function fileURLToPath(raw: string): string {
+  try {
+    const parsed = new URL(raw);
+    let path = decodeURIComponent(parsed.pathname);
+    // file:///C:/dir/main.html -> /C:/dir/main.html -> C:/dir/main.html
+    if (/^\/[A-Za-z]:[\\/]/.test(path)) {
+      path = path.slice(1);
+    }
+    return path;
+  } catch {
+    return raw.replace(/^file:\/\//i, "");
+  }
+}

--- a/frontend/src/lib/tunnelCommand.test.ts
+++ b/frontend/src/lib/tunnelCommand.test.ts
@@ -59,6 +59,57 @@ describe("tunnelCommand", () => {
     );
   });
 
+  it("serves a static path with --serve for file share links", () => {
+    const options = {
+      currentOrigin: "https://localhost:4017",
+      target: "",
+      name: "my-app",
+      nameSeed: "web_portal",
+      relayUrls: ["https://localhost:4017"],
+      discovery: true,
+      thumbnailURL: "",
+      os: "unix" as const,
+      shareKind: "file" as const,
+      servePath: "/Users/me/site/main.html",
+    };
+
+    expect(buildTunnelCommand(options)).toBe(
+      [
+        "curl -ksSL https://localhost:4017/api/install.sh | bash",
+        "portal expose --serve /Users/me/site/main.html --name my-app --relays https://localhost:4017",
+      ].join("\n")
+    );
+  });
+
+  it("quotes serve paths that contain spaces per OS", () => {
+    const base = {
+      currentOrigin: "https://relay.example.com",
+      target: "",
+      name: "my-app",
+      nameSeed: "web_portal",
+      relayUrls: ["https://relay.example.com"],
+      discovery: true,
+      thumbnailURL: "",
+      shareKind: "file" as const,
+    };
+
+    expect(
+      buildTunnelCommand({
+        ...base,
+        os: "unix",
+        servePath: "/Users/me/my site/main.html",
+      })
+    ).toContain("portal expose --serve '/Users/me/my site/main.html' --name my-app");
+
+    expect(
+      buildTunnelCommand({
+        ...base,
+        os: "windows",
+        servePath: "C:\\Users\\me\\site\\main.html",
+      })
+    ).toContain(`portal expose --serve 'C:\\Users\\me\\site\\main.html' --name my-app`);
+  });
+
   it("uses the relay root host for preview URLs instead of a placeholder host", () => {
     expect(
       buildTunnelPreviewURL(

--- a/frontend/src/lib/tunnelCommand.ts
+++ b/frontend/src/lib/tunnelCommand.ts
@@ -1,5 +1,6 @@
 import { BROWSER_API_PATHS } from "@/lib/apiPaths";
 import { resolveExposeName } from "@/lib/exposeName";
+import type { ShareKind } from "@/lib/shareLink";
 
 export type TunnelCommandOS = "unix" | "windows";
 
@@ -14,61 +15,25 @@ export interface TunnelCommandOptions {
   enableUDP?: boolean;
   udpPort?: string;
   os: TunnelCommandOS;
+  /** How the share input was classified; defaults to "port". */
+  shareKind?: ShareKind;
+  /** Local path passed to `--serve` when shareKind is "file". */
+  servePath?: string;
 }
 
 
-export function buildTunnelCommand({
-  currentOrigin,
-  discovery,
-  enableUDP = false,
-  name,
-  nameSeed,
-  os,
-  relayUrls,
-  target,
-  thumbnailURL,
-  udpPort = "",
-}: TunnelCommandOptions): string {
-  const { installLine, exposeHead, exposeOptions } = buildTunnelCommandParts({
-    currentOrigin,
-    discovery,
-    enableUDP,
-    name,
-    nameSeed,
-    os,
-    relayUrls,
-    target,
-    thumbnailURL,
-    udpPort,
-  });
+export function buildTunnelCommand(options: TunnelCommandOptions): string {
+  const { installLine, exposeHead, exposeOptions } =
+    buildTunnelCommandParts(options);
 
   return joinTunnelCommand(installLine, exposeHead, exposeOptions);
 }
 
-export function buildTunnelDisplayCommand({
-  currentOrigin,
-  discovery,
-  enableUDP = false,
-  name,
-  nameSeed,
-  os,
-  relayUrls,
-  target,
-  thumbnailURL,
-  udpPort = "",
-}: TunnelCommandOptions): string {
-  const { installLine, exposeHead, exposeOptions } = buildTunnelCommandParts({
-    currentOrigin,
-    discovery,
-    enableUDP,
-    name,
-    nameSeed,
-    os,
-    relayUrls,
-    target,
-    thumbnailURL,
-    udpPort,
-  });
+export function buildTunnelDisplayCommand(
+  options: TunnelCommandOptions
+): string {
+  const { installLine, exposeHead, exposeOptions } =
+    buildTunnelCommandParts(options);
 
   return joinTunnelCommand(installLine, exposeHead, exposeOptions);
 }
@@ -84,15 +49,22 @@ function buildTunnelCommandParts({
   target,
   thumbnailURL,
   udpPort = "",
+  shareKind = "port",
+  servePath = "",
 }: TunnelCommandOptions): {
   installLine: string;
   exposeHead: string;
   exposeOptions: string[];
 } {
+  const isFile = shareKind === "file";
   const targetValue = target.trim() === "" ? "3000" : target.trim();
-  const nameValue = resolveExposeName(name, targetValue, nameSeed);
+  const nameSeedTarget = isFile ? servePath : targetValue;
+  const nameValue = resolveExposeName(name, nameSeedTarget, nameSeed);
   const relayURLValue =
     relayUrls.length > 0 ? relayUrls.join(",") : currentOrigin;
+  const leadingArgs = isFile
+    ? ["--serve", formatToken(servePath, os)]
+    : [formatToken(targetValue, os)];
   const installScriptURL = new URL(
     BROWSER_API_PATHS.install.shell,
     currentOrigin
@@ -131,7 +103,7 @@ function buildTunnelCommandParts({
         `irm ${formatToken(installPowerShellURL, os)} | iex`,
       ].join("\n"),
       exposeHead: "portal expose",
-      exposeOptions: [formatToken(targetValue, os), ...exposeArgs],
+      exposeOptions: [...leadingArgs, ...exposeArgs],
     };
   }
 
@@ -139,7 +111,7 @@ function buildTunnelCommandParts({
   return {
     installLine: `curl ${curlFlags} ${formatToken(installScriptURL, os)} | bash`,
     exposeHead: "portal expose",
-    exposeOptions: [formatToken(targetValue, os), ...exposeArgs],
+    exposeOptions: [...leadingArgs, ...exposeArgs],
   };
 }
 

--- a/sdk/http.go
+++ b/sdk/http.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/http/httputil"
 	"net/url"
+	"path"
 	"sort"
 	"strings"
 	"sync"
@@ -128,7 +129,15 @@ type HTTPRouteConfig struct {
 	// Prefix is the public request path prefix, such as "/api" or "/".
 	Prefix string
 	// Upstream is the target HTTP URL, or a loopback host:port shorthand.
+	// Leave empty when StaticRoot is set.
 	Upstream string
+	// StaticRoot, when set, serves files from this local directory as a static
+	// SPA instead of proxying to an Upstream. Unknown paths fall back to
+	// StaticIndex (CSR routing); paths escaping the directory are refused.
+	StaticRoot string
+	// StaticIndex is the SPA entry file served for the root and any unknown
+	// path under a static route. Defaults to "index.html" when empty.
+	StaticIndex string
 	// Methods limits payment to these HTTP methods. Empty means every method.
 	Methods []string
 	// Amount enables Sui USDC x402 payment for this public path prefix.
@@ -235,6 +244,8 @@ type httpRoute struct {
 	upstream       *url.URL
 	upstreamPath   string
 	upstreamDomain string
+	staticRoot     string
+	staticIndex    string
 	payment        *x402.Payment
 	paymentMethods map[string]struct{}
 	handler        http.Handler
@@ -250,36 +261,49 @@ func newHTTPRoute(routeConfig HTTPRouteConfig, x402PayTo string, x402Testnet boo
 	}
 	prefix = utils.NormalizeURLPath(prefix)
 
-	upstreamInput := strings.TrimSpace(routeConfig.Upstream)
-	if upstreamInput == "" {
-		return nil, fmt.Errorf("http route %q upstream is required", prefix)
-	}
-	if !strings.Contains(upstreamInput, "://") {
-		target, err := utils.NormalizeLoopbackTarget(upstreamInput)
+	var route *httpRoute
+	if staticRoot := strings.TrimSpace(routeConfig.StaticRoot); staticRoot != "" {
+		staticIndex := strings.TrimSpace(routeConfig.StaticIndex)
+		if staticIndex == "" {
+			staticIndex = "index.html"
+		}
+		route = &httpRoute{
+			prefix:      prefix,
+			staticRoot:  staticRoot,
+			staticIndex: staticIndex,
+		}
+	} else {
+		upstreamInput := strings.TrimSpace(routeConfig.Upstream)
+		if upstreamInput == "" {
+			return nil, fmt.Errorf("http route %q upstream is required", prefix)
+		}
+		if !strings.Contains(upstreamInput, "://") {
+			target, err := utils.NormalizeLoopbackTarget(upstreamInput)
+			if err != nil {
+				return nil, fmt.Errorf("http route %q upstream: %w", prefix, err)
+			}
+			upstreamInput = "http://" + target
+		}
+
+		upstream, err := url.Parse(upstreamInput)
 		if err != nil {
 			return nil, fmt.Errorf("http route %q upstream: %w", prefix, err)
 		}
-		upstreamInput = "http://" + target
-	}
+		if upstream.Host == "" {
+			return nil, fmt.Errorf("http route %q upstream host is required", prefix)
+		}
+		if upstream.Scheme != "http" && upstream.Scheme != "https" {
+			return nil, fmt.Errorf("http route %q upstream scheme must be http or https", prefix)
+		}
+		upstream.Fragment = ""
+		upstream.Path = utils.NormalizeURLPath(upstream.Path)
 
-	upstream, err := url.Parse(upstreamInput)
-	if err != nil {
-		return nil, fmt.Errorf("http route %q upstream: %w", prefix, err)
-	}
-	if upstream.Host == "" {
-		return nil, fmt.Errorf("http route %q upstream host is required", prefix)
-	}
-	if upstream.Scheme != "http" && upstream.Scheme != "https" {
-		return nil, fmt.Errorf("http route %q upstream scheme must be http or https", prefix)
-	}
-	upstream.Fragment = ""
-	upstream.Path = utils.NormalizeURLPath(upstream.Path)
-
-	route := &httpRoute{
-		prefix:         prefix,
-		upstream:       upstream,
-		upstreamPath:   upstream.Path,
-		upstreamDomain: utils.NormalizeHostname(upstream.Hostname()),
+		route = &httpRoute{
+			prefix:         prefix,
+			upstream:       upstream,
+			upstreamPath:   upstream.Path,
+			upstreamDomain: utils.NormalizeHostname(upstream.Hostname()),
+		}
 	}
 	amount := strings.TrimSpace(routeConfig.Amount)
 	if amount == "" && len(routeConfig.Methods) > 0 {
@@ -312,7 +336,32 @@ func newHTTPRoute(routeConfig HTTPRouteConfig, x402PayTo string, x402Testnet boo
 }
 
 func (r *httpRoute) newHandler() http.Handler {
-	proxy := &httputil.ReverseProxy{
+	base := r.baseHandler()
+	if r.payment == nil {
+		return base
+	}
+	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		if len(r.paymentMethods) > 0 {
+			if _, ok := r.paymentMethods[strings.ToUpper(req.Method)]; !ok {
+				base.ServeHTTP(w, req)
+				return
+			}
+		}
+
+		settled, ok := r.payment.Settle(req.Context(), w, req)
+		if !ok {
+			return
+		}
+		utils.SetPaymentResponseHeaders(w.Header(), settled)
+		base.ServeHTTP(w, req)
+	})
+}
+
+func (r *httpRoute) baseHandler() http.Handler {
+	if r.staticRoot != "" {
+		return r.newStaticHandler()
+	}
+	return &httputil.ReverseProxy{
 		Rewrite:        r.rewriteProxyRequest,
 		ModifyResponse: r.rewriteProxyResponse,
 		ErrorHandler: func(w http.ResponseWriter, req *http.Request, err error) {
@@ -323,24 +372,86 @@ func (r *httpRoute) newHandler() http.Handler {
 			http.Error(w, "bad gateway", http.StatusBadGateway)
 		},
 	}
-	if r.payment == nil {
-		return proxy
-	}
-	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-		if len(r.paymentMethods) > 0 {
-			if _, ok := r.paymentMethods[strings.ToUpper(req.Method)]; !ok {
-				proxy.ServeHTTP(w, req)
-				return
-			}
-		}
+}
 
-		settled, ok := r.payment.Settle(req.Context(), w, req)
+// newStaticHandler serves files under staticRoot with SPA/CSR fallback: a
+// concrete file is served as-is, while the root and any unknown path return
+// staticIndex. http.Dir already refuses paths that escape the root directory.
+func (r *httpRoute) newStaticHandler() http.Handler {
+	root := http.Dir(r.staticRoot)
+	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		rel, ok := staticRequestPath(r.prefix, req.URL.Path)
 		if !ok {
+			http.NotFound(w, req)
 			return
 		}
-		utils.SetPaymentResponseHeaders(w.Header(), settled)
-		proxy.ServeHTTP(w, req)
+		if rel != "/" && serveStaticFile(w, req, root, rel) {
+			return
+		}
+		serveStaticIndex(w, req, root, r.staticIndex)
 	})
+}
+
+// staticRequestPath strips the route prefix and returns a clean, root-relative
+// path. It reports false for parent-directory traversal attempts.
+func staticRequestPath(prefix, urlPath string) (string, bool) {
+	p := utils.NormalizeURLPath(urlPath)
+	if prefix != "/" {
+		switch {
+		case p == prefix:
+			p = "/"
+		case strings.HasPrefix(p, prefix+"/"):
+			p = strings.TrimPrefix(p, prefix)
+		}
+	}
+	if !strings.HasPrefix(p, "/") {
+		p = "/" + p
+	}
+	if containsDotDot(p) {
+		return "", false
+	}
+	return path.Clean(p), true
+}
+
+func containsDotDot(v string) bool {
+	if !strings.Contains(v, "..") {
+		return false
+	}
+	for _, ent := range strings.FieldsFunc(v, func(r rune) bool { return r == '/' || r == '\\' }) {
+		if ent == ".." {
+			return true
+		}
+	}
+	return false
+}
+
+func serveStaticFile(w http.ResponseWriter, req *http.Request, root http.FileSystem, rel string) bool {
+	f, err := root.Open(rel)
+	if err != nil {
+		return false
+	}
+	defer f.Close()
+	info, err := f.Stat()
+	if err != nil || info.IsDir() {
+		return false
+	}
+	http.ServeContent(w, req, info.Name(), info.ModTime(), f)
+	return true
+}
+
+func serveStaticIndex(w http.ResponseWriter, req *http.Request, root http.FileSystem, index string) {
+	f, err := root.Open("/" + index)
+	if err != nil {
+		http.NotFound(w, req)
+		return
+	}
+	defer f.Close()
+	info, err := f.Stat()
+	if err != nil || info.IsDir() {
+		http.NotFound(w, req)
+		return
+	}
+	http.ServeContent(w, req, info.Name(), info.ModTime(), f)
 }
 
 func (r *httpRoute) rewriteProxyRequest(pr *httputil.ProxyRequest) {

--- a/sdk/http.go
+++ b/sdk/http.go
@@ -9,7 +9,6 @@ import (
 	"net/http"
 	"net/http/httputil"
 	"net/url"
-	"path"
 	"sort"
 	"strings"
 	"sync"
@@ -265,7 +264,7 @@ func newHTTPRoute(routeConfig HTTPRouteConfig, x402PayTo string, x402Testnet boo
 	if staticRoot := strings.TrimSpace(routeConfig.StaticRoot); staticRoot != "" {
 		staticIndex := strings.TrimSpace(routeConfig.StaticIndex)
 		if staticIndex == "" {
-			staticIndex = "index.html"
+			staticIndex = utils.DefaultStaticIndex
 		}
 		route = &httpRoute{
 			prefix:      prefix,
@@ -359,7 +358,7 @@ func (r *httpRoute) newHandler() http.Handler {
 
 func (r *httpRoute) baseHandler() http.Handler {
 	if r.staticRoot != "" {
-		return r.newStaticHandler()
+		return utils.NewStaticSiteHandler(r.prefix, r.staticRoot, r.staticIndex)
 	}
 	return &httputil.ReverseProxy{
 		Rewrite:        r.rewriteProxyRequest,
@@ -372,86 +371,6 @@ func (r *httpRoute) baseHandler() http.Handler {
 			http.Error(w, "bad gateway", http.StatusBadGateway)
 		},
 	}
-}
-
-// newStaticHandler serves files under staticRoot with SPA/CSR fallback: a
-// concrete file is served as-is, while the root and any unknown path return
-// staticIndex. http.Dir already refuses paths that escape the root directory.
-func (r *httpRoute) newStaticHandler() http.Handler {
-	root := http.Dir(r.staticRoot)
-	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-		rel, ok := staticRequestPath(r.prefix, req.URL.Path)
-		if !ok {
-			http.NotFound(w, req)
-			return
-		}
-		if rel != "/" && serveStaticFile(w, req, root, rel) {
-			return
-		}
-		serveStaticIndex(w, req, root, r.staticIndex)
-	})
-}
-
-// staticRequestPath strips the route prefix and returns a clean, root-relative
-// path. It reports false for parent-directory traversal attempts.
-func staticRequestPath(prefix, urlPath string) (string, bool) {
-	p := utils.NormalizeURLPath(urlPath)
-	if prefix != "/" {
-		switch {
-		case p == prefix:
-			p = "/"
-		case strings.HasPrefix(p, prefix+"/"):
-			p = strings.TrimPrefix(p, prefix)
-		}
-	}
-	if !strings.HasPrefix(p, "/") {
-		p = "/" + p
-	}
-	if containsDotDot(p) {
-		return "", false
-	}
-	return path.Clean(p), true
-}
-
-func containsDotDot(v string) bool {
-	if !strings.Contains(v, "..") {
-		return false
-	}
-	for _, ent := range strings.FieldsFunc(v, func(r rune) bool { return r == '/' || r == '\\' }) {
-		if ent == ".." {
-			return true
-		}
-	}
-	return false
-}
-
-func serveStaticFile(w http.ResponseWriter, req *http.Request, root http.FileSystem, rel string) bool {
-	f, err := root.Open(rel)
-	if err != nil {
-		return false
-	}
-	defer f.Close()
-	info, err := f.Stat()
-	if err != nil || info.IsDir() {
-		return false
-	}
-	http.ServeContent(w, req, info.Name(), info.ModTime(), f)
-	return true
-}
-
-func serveStaticIndex(w http.ResponseWriter, req *http.Request, root http.FileSystem, index string) {
-	f, err := root.Open("/" + index)
-	if err != nil {
-		http.NotFound(w, req)
-		return
-	}
-	defer f.Close()
-	info, err := f.Stat()
-	if err != nil || info.IsDir() {
-		http.NotFound(w, req)
-		return
-	}
-	http.ServeContent(w, req, info.Name(), info.ModTime(), f)
 }
 
 func (r *httpRoute) rewriteProxyRequest(pr *httputil.ProxyRequest) {

--- a/sdk/http_test.go
+++ b/sdk/http_test.go
@@ -3,6 +3,8 @@ package sdk
 import (
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -83,5 +85,182 @@ func TestHTTPRoutesRejectDuplicateNormalizedPrefixes(t *testing.T) {
 	}, "", false)
 	if err == nil {
 		t.Fatal("NewHTTPRoutes() error = nil, want duplicate prefix error")
+	}
+}
+
+func newStaticSite(t *testing.T, files map[string]string) string {
+	t.Helper()
+	root := t.TempDir()
+	for name, content := range files {
+		full := filepath.Join(root, filepath.FromSlash(name))
+		if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+			t.Fatalf("MkdirAll(%q) error = %v", name, err)
+		}
+		if err := os.WriteFile(full, []byte(content), 0o644); err != nil {
+			t.Fatalf("WriteFile(%q) error = %v", name, err)
+		}
+	}
+	return root
+}
+
+func TestHTTPRoutesStaticServesConcreteFile(t *testing.T) {
+	t.Parallel()
+
+	root := newStaticSite(t, map[string]string{
+		"index.html":     "<html>index</html>",
+		"assets/app.css": "body{color:red}",
+	})
+	handler, err := NewHTTPRoutes([]HTTPRouteConfig{
+		{Prefix: "/", StaticRoot: root},
+	}, "", false)
+	if err != nil {
+		t.Fatalf("NewHTTPRoutes() error = %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "https://public.example/assets/app.css", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	if got := rec.Body.String(); got != "body{color:red}" {
+		t.Fatalf("body = %q, want css content", got)
+	}
+	if ct := rec.Header().Get("Content-Type"); !strings.HasPrefix(ct, "text/css") {
+		t.Fatalf("Content-Type = %q, want text/css", ct)
+	}
+}
+
+func TestHTTPRoutesStaticSPAFallback(t *testing.T) {
+	t.Parallel()
+
+	root := newStaticSite(t, map[string]string{
+		"index.html": "<html>spa</html>",
+	})
+	handler, err := NewHTTPRoutes([]HTTPRouteConfig{
+		{Prefix: "/", StaticRoot: root},
+	}, "", false)
+	if err != nil {
+		t.Fatalf("NewHTTPRoutes() error = %v", err)
+	}
+
+	for _, target := range []string{"https://public.example/", "https://public.example/deep/client/route"} {
+		req := httptest.NewRequest(http.MethodGet, target, nil)
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, req)
+
+		if rec.Code != http.StatusOK {
+			t.Fatalf("%s status = %d, want 200", target, rec.Code)
+		}
+		if got := rec.Body.String(); got != "<html>spa</html>" {
+			t.Fatalf("%s body = %q, want index content", target, got)
+		}
+	}
+}
+
+func TestHTTPRoutesStaticCustomIndex(t *testing.T) {
+	t.Parallel()
+
+	root := newStaticSite(t, map[string]string{
+		"main.html": "<html>main</html>",
+	})
+	handler, err := NewHTTPRoutes([]HTTPRouteConfig{
+		{Prefix: "/", StaticRoot: root, StaticIndex: "main.html"},
+	}, "", false)
+	if err != nil {
+		t.Fatalf("NewHTTPRoutes() error = %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "https://public.example/", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if got := rec.Body.String(); got != "<html>main</html>" {
+		t.Fatalf("body = %q, want main.html content", got)
+	}
+}
+
+func TestHTTPRoutesStaticDirectoryReturnsIndex(t *testing.T) {
+	t.Parallel()
+
+	root := newStaticSite(t, map[string]string{
+		"index.html":   "<html>index</html>",
+		"sub/keep.txt": "keep",
+	})
+	handler, err := NewHTTPRoutes([]HTTPRouteConfig{
+		{Prefix: "/", StaticRoot: root},
+	}, "", false)
+	if err != nil {
+		t.Fatalf("NewHTTPRoutes() error = %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "https://public.example/sub", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	if got := rec.Body.String(); got != "<html>index</html>" {
+		t.Fatalf("body = %q, want index content (no directory listing)", got)
+	}
+}
+
+func TestHTTPRoutesStaticRejectsTraversal(t *testing.T) {
+	t.Parallel()
+
+	root := newStaticSite(t, map[string]string{
+		"index.html": "<html>index</html>",
+	})
+	// A secret file one level above the served root must never be reachable.
+	secret := filepath.Join(filepath.Dir(root), "secret.txt")
+	if err := os.WriteFile(secret, []byte("TOP-SECRET"), 0o644); err != nil {
+		t.Fatalf("WriteFile(secret) error = %v", err)
+	}
+	t.Cleanup(func() { _ = os.Remove(secret) })
+
+	handler, err := NewHTTPRoutes([]HTTPRouteConfig{
+		{Prefix: "/", StaticRoot: root},
+	}, "", false)
+	if err != nil {
+		t.Fatalf("NewHTTPRoutes() error = %v", err)
+	}
+
+	for _, target := range []string{"/../secret.txt", "/../../secret.txt", "/sub/../../secret.txt"} {
+		req := httptest.NewRequest(http.MethodGet, "https://public.example/", nil)
+		req.URL.Path = target
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, req)
+
+		if strings.Contains(rec.Body.String(), "TOP-SECRET") {
+			t.Fatalf("%s leaked the out-of-root secret file", target)
+		}
+	}
+}
+
+func TestHTTPRoutesStaticPaidRouteChallengesUnpaid(t *testing.T) {
+	t.Parallel()
+
+	root := newStaticSite(t, map[string]string{
+		"index.html": "<html>paid</html>",
+	})
+	payTo := "0x" + strings.Repeat("a", 64)
+	handler, err := NewHTTPRoutes([]HTTPRouteConfig{
+		{Prefix: "/", StaticRoot: root, Amount: "0.01"},
+	}, payTo, true)
+	if err != nil {
+		t.Fatalf("NewHTTPRoutes() error = %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "https://public.example/", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code == http.StatusOK {
+		t.Fatalf("unpaid request status = 200, want payment challenge")
+	}
+	if strings.Contains(rec.Body.String(), "paid") {
+		t.Fatalf("unpaid request served the static file body: %q", rec.Body.String())
 	}
 }

--- a/sdk/http_test.go
+++ b/sdk/http_test.go
@@ -88,83 +88,21 @@ func TestHTTPRoutesRejectDuplicateNormalizedPrefixes(t *testing.T) {
 	}
 }
 
-func newStaticSite(t *testing.T, files map[string]string) string {
+func newStaticSiteDir(t *testing.T, name, content string) string {
 	t.Helper()
 	root := t.TempDir()
-	for name, content := range files {
-		full := filepath.Join(root, filepath.FromSlash(name))
-		if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
-			t.Fatalf("MkdirAll(%q) error = %v", name, err)
-		}
-		if err := os.WriteFile(full, []byte(content), 0o644); err != nil {
-			t.Fatalf("WriteFile(%q) error = %v", name, err)
-		}
+	if err := os.WriteFile(filepath.Join(root, name), []byte(content), 0o644); err != nil {
+		t.Fatalf("WriteFile(%q) error = %v", name, err)
 	}
 	return root
 }
 
-func TestHTTPRoutesStaticServesConcreteFile(t *testing.T) {
+// Static route behavior is covered in utils; these cases pin the wiring from
+// HTTPRouteConfig through to the static handler.
+func TestHTTPRoutesServeStaticRoute(t *testing.T) {
 	t.Parallel()
 
-	root := newStaticSite(t, map[string]string{
-		"index.html":     "<html>index</html>",
-		"assets/app.css": "body{color:red}",
-	})
-	handler, err := NewHTTPRoutes([]HTTPRouteConfig{
-		{Prefix: "/", StaticRoot: root},
-	}, "", false)
-	if err != nil {
-		t.Fatalf("NewHTTPRoutes() error = %v", err)
-	}
-
-	req := httptest.NewRequest(http.MethodGet, "https://public.example/assets/app.css", nil)
-	rec := httptest.NewRecorder()
-	handler.ServeHTTP(rec, req)
-
-	if rec.Code != http.StatusOK {
-		t.Fatalf("status = %d, want 200", rec.Code)
-	}
-	if got := rec.Body.String(); got != "body{color:red}" {
-		t.Fatalf("body = %q, want css content", got)
-	}
-	if ct := rec.Header().Get("Content-Type"); !strings.HasPrefix(ct, "text/css") {
-		t.Fatalf("Content-Type = %q, want text/css", ct)
-	}
-}
-
-func TestHTTPRoutesStaticSPAFallback(t *testing.T) {
-	t.Parallel()
-
-	root := newStaticSite(t, map[string]string{
-		"index.html": "<html>spa</html>",
-	})
-	handler, err := NewHTTPRoutes([]HTTPRouteConfig{
-		{Prefix: "/", StaticRoot: root},
-	}, "", false)
-	if err != nil {
-		t.Fatalf("NewHTTPRoutes() error = %v", err)
-	}
-
-	for _, target := range []string{"https://public.example/", "https://public.example/deep/client/route"} {
-		req := httptest.NewRequest(http.MethodGet, target, nil)
-		rec := httptest.NewRecorder()
-		handler.ServeHTTP(rec, req)
-
-		if rec.Code != http.StatusOK {
-			t.Fatalf("%s status = %d, want 200", target, rec.Code)
-		}
-		if got := rec.Body.String(); got != "<html>spa</html>" {
-			t.Fatalf("%s body = %q, want index content", target, got)
-		}
-	}
-}
-
-func TestHTTPRoutesStaticCustomIndex(t *testing.T) {
-	t.Parallel()
-
-	root := newStaticSite(t, map[string]string{
-		"main.html": "<html>main</html>",
-	})
+	root := newStaticSiteDir(t, "main.html", "<html>main</html>")
 	handler, err := NewHTTPRoutes([]HTTPRouteConfig{
 		{Prefix: "/", StaticRoot: root, StaticIndex: "main.html"},
 	}, "", false)
@@ -172,79 +110,22 @@ func TestHTTPRoutesStaticCustomIndex(t *testing.T) {
 		t.Fatalf("NewHTTPRoutes() error = %v", err)
 	}
 
-	req := httptest.NewRequest(http.MethodGet, "https://public.example/", nil)
-	rec := httptest.NewRecorder()
-	handler.ServeHTTP(rec, req)
-
-	if got := rec.Body.String(); got != "<html>main</html>" {
-		t.Fatalf("body = %q, want main.html content", got)
-	}
-}
-
-func TestHTTPRoutesStaticDirectoryReturnsIndex(t *testing.T) {
-	t.Parallel()
-
-	root := newStaticSite(t, map[string]string{
-		"index.html":   "<html>index</html>",
-		"sub/keep.txt": "keep",
-	})
-	handler, err := NewHTTPRoutes([]HTTPRouteConfig{
-		{Prefix: "/", StaticRoot: root},
-	}, "", false)
-	if err != nil {
-		t.Fatalf("NewHTTPRoutes() error = %v", err)
-	}
-
-	req := httptest.NewRequest(http.MethodGet, "https://public.example/sub", nil)
+	req := httptest.NewRequest(http.MethodGet, "https://public.example/deep/route", nil)
 	rec := httptest.NewRecorder()
 	handler.ServeHTTP(rec, req)
 
 	if rec.Code != http.StatusOK {
 		t.Fatalf("status = %d, want 200", rec.Code)
 	}
-	if got := rec.Body.String(); got != "<html>index</html>" {
-		t.Fatalf("body = %q, want index content (no directory listing)", got)
-	}
-}
-
-func TestHTTPRoutesStaticRejectsTraversal(t *testing.T) {
-	t.Parallel()
-
-	root := newStaticSite(t, map[string]string{
-		"index.html": "<html>index</html>",
-	})
-	// A secret file one level above the served root must never be reachable.
-	secret := filepath.Join(filepath.Dir(root), "secret.txt")
-	if err := os.WriteFile(secret, []byte("TOP-SECRET"), 0o644); err != nil {
-		t.Fatalf("WriteFile(secret) error = %v", err)
-	}
-	t.Cleanup(func() { _ = os.Remove(secret) })
-
-	handler, err := NewHTTPRoutes([]HTTPRouteConfig{
-		{Prefix: "/", StaticRoot: root},
-	}, "", false)
-	if err != nil {
-		t.Fatalf("NewHTTPRoutes() error = %v", err)
-	}
-
-	for _, target := range []string{"/../secret.txt", "/../../secret.txt", "/sub/../../secret.txt"} {
-		req := httptest.NewRequest(http.MethodGet, "https://public.example/", nil)
-		req.URL.Path = target
-		rec := httptest.NewRecorder()
-		handler.ServeHTTP(rec, req)
-
-		if strings.Contains(rec.Body.String(), "TOP-SECRET") {
-			t.Fatalf("%s leaked the out-of-root secret file", target)
-		}
+	if got := rec.Body.String(); got != "<html>main</html>" {
+		t.Fatalf("body = %q, want the configured entry file", got)
 	}
 }
 
 func TestHTTPRoutesStaticPaidRouteChallengesUnpaid(t *testing.T) {
 	t.Parallel()
 
-	root := newStaticSite(t, map[string]string{
-		"index.html": "<html>paid</html>",
-	})
+	root := newStaticSiteDir(t, "index.html", "<html>paid</html>")
 	payTo := "0x" + strings.Repeat("a", 64)
 	handler, err := NewHTTPRoutes([]HTTPRouteConfig{
 		{Prefix: "/", StaticRoot: root, Amount: "0.01"},

--- a/utils/filepath.go
+++ b/utils/filepath.go
@@ -1,0 +1,129 @@
+package utils
+
+import (
+	"fmt"
+	"net/http"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+)
+
+// DefaultStaticIndex is the SPA entry file served for a directory and for any
+// unknown path under a static site.
+const DefaultStaticIndex = "index.html"
+
+// ResolveStaticSite turns a user-supplied path into a static site root
+// directory and its SPA entry file. A directory serves DefaultStaticIndex; a
+// file serves its parent directory with that file as the entry. The entry file
+// must exist. Callers add their own flag or field context to the error.
+func ResolveStaticSite(input string) (root string, index string, err error) {
+	abs, err := filepath.Abs(strings.TrimSpace(input))
+	if err != nil {
+		return "", "", err
+	}
+	info, err := os.Stat(abs)
+	if err != nil {
+		return "", "", err
+	}
+	if info.IsDir() {
+		root, index = abs, DefaultStaticIndex
+	} else {
+		root, index = filepath.Dir(abs), filepath.Base(abs)
+	}
+
+	indexInfo, err := os.Stat(filepath.Join(root, index))
+	if err != nil {
+		return "", "", fmt.Errorf("entry file %q not found: %w", index, err)
+	}
+	if indexInfo.IsDir() {
+		return "", "", fmt.Errorf("entry %q is a directory", index)
+	}
+	return root, index, nil
+}
+
+// StaticSiteRequestPath strips the route prefix from a request path and returns
+// a clean, root-relative path. It reports false for parent-directory traversal.
+func StaticSiteRequestPath(prefix, urlPath string) (string, bool) {
+	// Reject before normalizing: NormalizeURLPath cleans ".." away, so a check
+	// after it would never fire.
+	if containsDotDot(urlPath) {
+		return "", false
+	}
+
+	p := NormalizeURLPath(urlPath)
+	if prefix != "/" {
+		switch {
+		case p == prefix:
+			p = "/"
+		case strings.HasPrefix(p, prefix+"/"):
+			p = strings.TrimPrefix(p, prefix)
+		}
+	}
+	if !strings.HasPrefix(p, "/") {
+		p = "/" + p
+	}
+	return path.Clean(p), true
+}
+
+// NewStaticSiteHandler serves files under root with SPA/CSR fallback: a
+// concrete file is served as-is, while the root and any unknown path return
+// index. http.Dir already refuses paths that escape the root directory.
+func NewStaticSiteHandler(prefix, root, index string) http.Handler {
+	if strings.TrimSpace(index) == "" {
+		index = DefaultStaticIndex
+	}
+	dir := http.Dir(root)
+	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		rel, ok := StaticSiteRequestPath(prefix, req.URL.Path)
+		if !ok {
+			http.NotFound(w, req)
+			return
+		}
+		if rel != "/" && serveStaticFile(w, req, dir, rel) {
+			return
+		}
+		serveStaticIndex(w, req, dir, index)
+	})
+}
+
+func containsDotDot(v string) bool {
+	if !strings.Contains(v, "..") {
+		return false
+	}
+	for _, ent := range strings.FieldsFunc(v, func(r rune) bool { return r == '/' || r == '\\' }) {
+		if ent == ".." {
+			return true
+		}
+	}
+	return false
+}
+
+func serveStaticFile(w http.ResponseWriter, req *http.Request, dir http.FileSystem, rel string) bool {
+	f, err := dir.Open(rel)
+	if err != nil {
+		return false
+	}
+	defer f.Close()
+	info, err := f.Stat()
+	if err != nil || info.IsDir() {
+		return false
+	}
+	http.ServeContent(w, req, info.Name(), info.ModTime(), f)
+	return true
+}
+
+func serveStaticIndex(w http.ResponseWriter, req *http.Request, dir http.FileSystem, index string) {
+	f, err := dir.Open("/" + index)
+	if err != nil {
+		http.NotFound(w, req)
+		return
+	}
+	defer f.Close()
+	info, err := f.Stat()
+	if err != nil || info.IsDir() {
+		http.NotFound(w, req)
+		return
+	}
+	http.ServeContent(w, req, info.Name(), info.ModTime(), f)
+}

--- a/utils/filepath_test.go
+++ b/utils/filepath_test.go
@@ -1,0 +1,215 @@
+package utils
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func newStaticSite(t *testing.T, files map[string]string) string {
+	t.Helper()
+	root := t.TempDir()
+	for name, content := range files {
+		full := filepath.Join(root, filepath.FromSlash(name))
+		if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+			t.Fatalf("MkdirAll(%q) error = %v", name, err)
+		}
+		if err := os.WriteFile(full, []byte(content), 0o644); err != nil {
+			t.Fatalf("WriteFile(%q) error = %v", name, err)
+		}
+	}
+	return root
+}
+
+func TestResolveStaticSiteDirectoryUsesDefaultIndex(t *testing.T) {
+	t.Parallel()
+
+	dir := newStaticSite(t, map[string]string{"index.html": "<html>index</html>"})
+
+	root, index, err := ResolveStaticSite(dir)
+	if err != nil {
+		t.Fatalf("ResolveStaticSite() error = %v", err)
+	}
+	if root != dir {
+		t.Fatalf("root = %q, want %q", root, dir)
+	}
+	if index != DefaultStaticIndex {
+		t.Fatalf("index = %q, want %q", index, DefaultStaticIndex)
+	}
+}
+
+func TestResolveStaticSiteFileUsesParentDirectory(t *testing.T) {
+	t.Parallel()
+
+	dir := newStaticSite(t, map[string]string{"main.html": "<html>main</html>"})
+
+	root, index, err := ResolveStaticSite(filepath.Join(dir, "main.html"))
+	if err != nil {
+		t.Fatalf("ResolveStaticSite() error = %v", err)
+	}
+	if root != dir {
+		t.Fatalf("root = %q, want %q", root, dir)
+	}
+	if index != "main.html" {
+		t.Fatalf("index = %q, want main.html", index)
+	}
+}
+
+func TestResolveStaticSiteRejectsMissingEntry(t *testing.T) {
+	t.Parallel()
+
+	// A directory without index.html has no SPA entry to fall back to.
+	dir := newStaticSite(t, map[string]string{"assets/app.css": "body{}"})
+	if _, _, err := ResolveStaticSite(dir); err == nil {
+		t.Fatal("ResolveStaticSite() error = nil, want missing entry error")
+	}
+
+	if _, _, err := ResolveStaticSite(filepath.Join(dir, "nope")); err == nil {
+		t.Fatal("ResolveStaticSite() error = nil, want missing path error")
+	}
+}
+
+func TestStaticSiteRequestPathStripsPrefixAndRejectsTraversal(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		prefix  string
+		urlPath string
+		want    string
+		wantOK  bool
+	}{
+		{name: "root prefix", prefix: "/", urlPath: "/assets/app.css", want: "/assets/app.css", wantOK: true},
+		{name: "prefix exact", prefix: "/app", urlPath: "/app", want: "/", wantOK: true},
+		{name: "prefix stripped", prefix: "/app", urlPath: "/app/assets/app.css", want: "/assets/app.css", wantOK: true},
+		{name: "traversal", prefix: "/", urlPath: "/../secret.txt", want: "", wantOK: false},
+		{name: "nested traversal", prefix: "/", urlPath: "/sub/../../secret.txt", want: "", wantOK: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, ok := StaticSiteRequestPath(tt.prefix, tt.urlPath)
+			if ok != tt.wantOK {
+				t.Fatalf("ok = %v, want %v", ok, tt.wantOK)
+			}
+			if got != tt.want {
+				t.Fatalf("path = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestStaticSiteHandlerServesConcreteFile(t *testing.T) {
+	t.Parallel()
+
+	root := newStaticSite(t, map[string]string{
+		"index.html":     "<html>index</html>",
+		"assets/app.css": "body{color:red}",
+	})
+	handler := NewStaticSiteHandler("/", root, DefaultStaticIndex)
+
+	req := httptest.NewRequest(http.MethodGet, "https://public.example/assets/app.css", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	if got := rec.Body.String(); got != "body{color:red}" {
+		t.Fatalf("body = %q, want css content", got)
+	}
+	if ct := rec.Header().Get("Content-Type"); !strings.HasPrefix(ct, "text/css") {
+		t.Fatalf("Content-Type = %q, want text/css", ct)
+	}
+}
+
+func TestStaticSiteHandlerFallsBackToIndex(t *testing.T) {
+	t.Parallel()
+
+	root := newStaticSite(t, map[string]string{"index.html": "<html>spa</html>"})
+	handler := NewStaticSiteHandler("/", root, "")
+
+	// The root, an unknown client-side route, and a directory all return the
+	// entry file so client-side routing works and nothing is listed.
+	for _, target := range []string{
+		"https://public.example/",
+		"https://public.example/deep/client/route",
+	} {
+		req := httptest.NewRequest(http.MethodGet, target, nil)
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, req)
+
+		if rec.Code != http.StatusOK {
+			t.Fatalf("%s status = %d, want 200", target, rec.Code)
+		}
+		if got := rec.Body.String(); got != "<html>spa</html>" {
+			t.Fatalf("%s body = %q, want index content", target, got)
+		}
+	}
+}
+
+func TestStaticSiteHandlerServesCustomIndex(t *testing.T) {
+	t.Parallel()
+
+	root := newStaticSite(t, map[string]string{"main.html": "<html>main</html>"})
+	handler := NewStaticSiteHandler("/", root, "main.html")
+
+	req := httptest.NewRequest(http.MethodGet, "https://public.example/", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if got := rec.Body.String(); got != "<html>main</html>" {
+		t.Fatalf("body = %q, want main.html content", got)
+	}
+}
+
+func TestStaticSiteHandlerReturnsIndexForDirectory(t *testing.T) {
+	t.Parallel()
+
+	root := newStaticSite(t, map[string]string{
+		"index.html":   "<html>index</html>",
+		"sub/keep.txt": "keep",
+	})
+	handler := NewStaticSiteHandler("/", root, DefaultStaticIndex)
+
+	req := httptest.NewRequest(http.MethodGet, "https://public.example/sub", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	if got := rec.Body.String(); got != "<html>index</html>" {
+		t.Fatalf("body = %q, want index content (no directory listing)", got)
+	}
+}
+
+func TestStaticSiteHandlerRejectsTraversal(t *testing.T) {
+	t.Parallel()
+
+	root := newStaticSite(t, map[string]string{"index.html": "<html>index</html>"})
+	// A secret file one level above the served root must never be reachable.
+	secret := filepath.Join(filepath.Dir(root), "secret.txt")
+	if err := os.WriteFile(secret, []byte("TOP-SECRET"), 0o644); err != nil {
+		t.Fatalf("WriteFile(secret) error = %v", err)
+	}
+	t.Cleanup(func() { _ = os.Remove(secret) })
+
+	handler := NewStaticSiteHandler("/", root, DefaultStaticIndex)
+
+	for _, target := range []string{"/../secret.txt", "/../../secret.txt", "/sub/../../secret.txt"} {
+		req := httptest.NewRequest(http.MethodGet, "https://public.example/", nil)
+		req.URL.Path = target
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, req)
+
+		if strings.Contains(rec.Body.String(), "TOP-SECRET") {
+			t.Fatalf("%s leaked the out-of-root secret file", target)
+		}
+	}
+}


### PR DESCRIPTION
Closes #280

## Problem

The quick start only accepted a port and emitted `portal expose <port>`. People
paste other things — a `file:///…/index.html` path from their browser, a Windows
path, or a full `http://…` URL — and none of those worked. Sharing a plain
folder of HTML was impossible without first running a local web server.

## What changed

### Tunnel: `portal expose --serve <path>`

Publishes a local folder as a static site. Pass a directory (served with
`index.html`) or an HTML file (its folder is served with that file as the
SPA/CSR entry).

```bash
portal expose --serve ./site --name my-app
portal expose --serve ./site/main.html --name my-app
```

- Unknown paths return the entry file with `200`, so client-side routing works.
- Concrete files are served through `http.ServeContent`, keeping `Content-Type`,
  `ETag`, and range requests correct.
- Directory listing is off; a directory request returns the entry file.
- Paths escaping the served folder are refused.
- Implemented as a static variant of `HTTPRouteConfig` (`StaticRoot` /
  `StaticIndex`), so it reuses the existing routed-HTTP pipeline — prefix
  routing and x402 gating keep working unchanged, and the relay needs no
  changes at all.
- Mutually exclusive with a positional target, `--http-route`, `--udp`, and
  `--tcp`; the entry file must exist.

### Quick start forms: one input, three kinds of share

Both forms — the React relay UI (`frontend/`, what operators see on a
self-hosted relay) and the SvelteKit landing (`docs/`) — now classify what was
pasted and generate the matching command:

| Input | Detected | Command |
| --- | --- | --- |
| `3000`, `localhost:8080` | Port | `portal expose 3000 …` |
| `http://localhost:3000/x` | URL | `portal expose localhost:3000 …` |
| `file:///Users/me/site/index.html` | File | `portal expose --serve /Users/me/site/index.html …` |
| `C:\Users\me\site\main.html` | File | `portal expose --serve 'C:\Users\me\site\main.html' …` |

- The field starts empty with a link-first placeholder instead of a prefilled
  `3000`, and gets its own full-width row so a pasted path stays readable.
- A badge shows how the input was read, once something is entered.
- Step one now says "Paste what you want to share" and explains that a file path
  is served straight from that folder, so nothing has to be running locally.
- Paths are quoted per OS, so spaces and backslashes survive copy/paste.

## Notes

- `http.Dir` refuses `..` traversal, but a symlink inside the served folder that
  points outside it is still followed. Documented in the CLI README — only serve
  folders you trust.
- Serving is entirely tunnel-local. No relay-side change, no new API surface.

## Follow-ups (not in this PR)

- `portal agent` TOML `serve` field plus dashboard support.
- A full `--serve` entry in the docs CLI reference page.
- Allowing `--serve` alongside `--http-route` (static `/` plus a proxied `/api`).

## Testing

- `sdk/http_test.go`: concrete file with correct content type, SPA fallback
  returning `200`, out-of-root file never leaking through `..`, directory
  request returning the entry file, and an x402-gated static route challenging
  an unpaid request.
- `frontend/src/lib/shareLink.test.ts`: classification across port, `host:port`,
  http(s) URL, `file://` (POSIX and Windows), drive-letter, UNC, absolute POSIX,
  and empty input.
- `frontend/src/lib/tunnelCommand.test.ts`: file input emits `--serve`, and
  paths with spaces are quoted correctly for both shells.
- `go build ./...`, `go vet`, `go test ./sdk/...`, frontend `vitest`, `tsc`, and
  the docs build all pass. Verified end to end against a live relay.
