### PR TITLE
fix: address tidy-build review findings (frontend serving, policy locking, build flags)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ ARG TARGETARCH
 RUN --mount=type=cache,target=/go/pkg/mod \
   --mount=type=cache,target=/root/.cache/go-build \
   make build-tunnel && \
-  CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -trimpath -ldflags "-s -w" -o bin/relay-server ./cmd/relay-server
+  GOOS=${TARGETOS} GOARCH=${TARGETARCH} make build-server-bin
 
 FROM gcr.io/distroless/static-debian12:nonroot AS runtime
 

--- a/Makefile
+++ b/Makefile
@@ -92,9 +92,7 @@ build-tunnel:
 # Build Go relay server
 build-server: build-frontend build-server-bin
 
-# Compile only the relay server binary; assumes frontend assets are already in
-# cmd/relay-server/dist/app (used by the Dockerfile, which builds them in a
-# separate stage).
+# Binary only; assumes frontend assets already exist in cmd/relay-server/dist/app.
 build-server-bin:
 	@echo "[server] building Go portal..."
 	CGO_ENABLED=0 go build $(GO_BUILD_FLAGS) -o bin/relay-server ./cmd/relay-server

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,9 @@
-.PHONY: help install fmt vet lint lint-auto test tidy all run build build-frontend build-docs build-tunnel build-server clean load-test
+.PHONY: help install fmt vet lint lint-auto test tidy all run build build-frontend build-docs build-tunnel build-server build-server-bin clean load-test
 
 .DEFAULT_GOAL := help
 
 GO_PACKAGES := ./cmd/... ./portal/... ./sdk/... ./types/... ./utils/...
+GO_BUILD_FLAGS := -trimpath -ldflags "-s -w"
 GO_TOOLCHAIN_VERSION := $(shell awk '/^go / { print "go" $$2; exit }' go.mod)
 GOIMPORTS_VERSION := v0.41.0
 GOLANGCI_LINT_VERSION := v2.11.1
@@ -57,7 +58,7 @@ run:
 	./bin/relay-server
 
 # Convenience target
-build: build-frontend build-tunnel build-server
+build: build-tunnel build-server
 
 # Build React frontend with Tailwind CSS 4
 build-frontend:
@@ -84,14 +85,19 @@ build-tunnel:
 			if [ "$${GOOS}" = "windows" ]; then EXT=".exe"; fi; \
 			OUT="cmd/relay-server/dist/tunnel/portal-$${GOOS}-$${GOARCH}$${EXT}"; \
 			echo " - $${OUT}"; \
-			CGO_ENABLED=0 GOOS=$${GOOS} GOARCH=$${GOARCH} go build -trimpath -ldflags "-s -w" -o "$${OUT}" ./cmd/portal-tunnel; \
+			CGO_ENABLED=0 GOOS=$${GOOS} GOARCH=$${GOARCH} go build $(GO_BUILD_FLAGS) -o "$${OUT}" ./cmd/portal-tunnel; \
 		done; \
 	done
 
 # Build Go relay server
-build-server: build-frontend
+build-server: build-frontend build-server-bin
+
+# Compile only the relay server binary; assumes frontend assets are already in
+# cmd/relay-server/dist/app (used by the Dockerfile, which builds them in a
+# separate stage).
+build-server-bin:
 	@echo "[server] building Go portal..."
-	CGO_ENABLED=0 go build -trimpath -ldflags "-s -w" -o bin/relay-server ./cmd/relay-server
+	CGO_ENABLED=0 go build $(GO_BUILD_FLAGS) -o bin/relay-server ./cmd/relay-server
 
 clean:
 	rm -rf bin

--- a/cmd/relay-server/api.go
+++ b/cmd/relay-server/api.go
@@ -31,11 +31,16 @@ const (
 )
 
 type RelayAPI struct {
-	server             *portal.Server
-	adminToken         string
-	policyStatePath    string
-	frontendFS         fs.FS
-	frontendCache      sync.Map
+	server               *portal.Server
+	adminToken           string
+	policyStatePath      string
+	frontendFS           fs.FS
+	frontendCache        sync.Map
+	frontendCacheEnabled bool
+	// policyWriteMu serializes policy mutations end to end, including the
+	// state-file write; policyMu only guards in-memory reads so readers never
+	// block on disk I/O.
+	policyWriteMu      sync.Mutex
 	policyMu           sync.RWMutex
 	landingPageEnabled bool
 }
@@ -58,11 +63,12 @@ func NewRelayAPI(server *portal.Server, identityPath, adminToken, frontendDir st
 	}
 
 	api := &RelayAPI{
-		server:             server,
-		adminToken:         strings.TrimSpace(adminToken),
-		policyStatePath:    strings.TrimSpace(policyStatePath),
-		frontendFS:         frontendFS,
-		landingPageEnabled: landingPageEnabled,
+		server:               server,
+		adminToken:           strings.TrimSpace(adminToken),
+		policyStatePath:      strings.TrimSpace(policyStatePath),
+		frontendFS:           frontendFS,
+		frontendCacheEnabled: strings.TrimSpace(frontendDir) == "",
+		landingPageEnabled:   landingPageEnabled,
 	}
 	if err := api.loadPolicyState(); err != nil {
 		return nil, err
@@ -190,16 +196,21 @@ func (api *RelayAPI) servePolicy(w http.ResponseWriter, r *http.Request) {
 			if !ok {
 				return
 			}
+			api.policyWriteMu.Lock()
+			defer api.policyWriteMu.Unlock()
 			api.policyMu.Lock()
-			defer api.policyMu.Unlock()
 			previous := api.policyState(runtime)
 			if !api.applyPolicySettings(w, runtime, req) {
+				api.policyMu.Unlock()
 				return
 			}
-			if !api.persistPolicyState(w, runtime, previous) {
+			payload := api.policyState(runtime)
+			settings := api.policySettings(runtime)
+			api.policyMu.Unlock()
+			if !api.persistPolicyState(w, previous, payload) {
 				return
 			}
-			utils.WriteAPIData(w, http.StatusOK, api.policySettings(runtime))
+			utils.WriteAPIData(w, http.StatusOK, settings)
 		default:
 			w.Header().Set("Allow", http.MethodGet+", "+http.MethodPost)
 			utils.MethodNotAllowedError().Write(w)
@@ -224,17 +235,21 @@ func (api *RelayAPI) servePolicy(w http.ResponseWriter, r *http.Request) {
 		if !ok {
 			return
 		}
-		api.policyMu.Lock()
-		defer api.policyMu.Unlock()
-		previous := api.policyState(runtime)
 		identityKey, ok := normalizePolicyIdentityKey(w, req.IdentityKey)
 		if !ok {
 			return
 		}
+		api.policyWriteMu.Lock()
+		defer api.policyWriteMu.Unlock()
+		api.policyMu.Lock()
+		previous := api.policyState(runtime)
 		if !applyLeasePolicyUpdate(w, runtime, identityKey, req) {
+			api.policyMu.Unlock()
 			return
 		}
-		if !api.persistPolicyState(w, runtime, previous) {
+		payload := api.policyState(runtime)
+		api.policyMu.Unlock()
+		if !api.persistPolicyState(w, previous, payload) {
 			return
 		}
 		utils.WriteAPIData(w, http.StatusOK, map[string]any{})
@@ -246,20 +261,23 @@ func (api *RelayAPI) servePolicy(w http.ResponseWriter, r *http.Request) {
 		if !ok {
 			return
 		}
-		api.policyMu.Lock()
-		defer api.policyMu.Unlock()
-		previous := api.policyState(runtime)
 		ip := strings.TrimSpace(req.IP)
 		if net.ParseIP(ip) == nil {
 			utils.WriteAPIError(w, http.StatusBadRequest, types.APIErrorCodeInvalidIP, "invalid IP address")
 			return
 		}
+		api.policyWriteMu.Lock()
+		defer api.policyWriteMu.Unlock()
+		api.policyMu.Lock()
+		previous := api.policyState(runtime)
 		if req.IsBanned {
 			runtime.IPFilter().BanIP(ip)
 		} else {
 			runtime.IPFilter().UnbanIP(ip)
 		}
-		if !api.persistPolicyState(w, runtime, previous) {
+		payload := api.policyState(runtime)
+		api.policyMu.Unlock()
+		if !api.persistPolicyState(w, previous, payload) {
 			return
 		}
 		utils.WriteAPIData(w, http.StatusOK, map[string]any{})
@@ -393,10 +411,13 @@ func (api *RelayAPI) tokenAllowed(raw string) bool {
 	return subtle.ConstantTimeCompare([]byte(token), []byte(expected)) == 1
 }
 
-func (api *RelayAPI) persistPolicyState(w http.ResponseWriter, runtime *policy.Runtime, previous persistedPolicyState) bool {
-	if err := api.savePolicyState(api.policyState(runtime)); err != nil {
+func (api *RelayAPI) persistPolicyState(w http.ResponseWriter, previous, payload persistedPolicyState) bool {
+	if err := api.savePolicyState(payload); err != nil {
 		log.Error().Err(err).Str("path", api.policyStatePath).Msg("persist relay policy state")
-		if rollbackErr := previous.apply(api); rollbackErr != nil {
+		api.policyMu.Lock()
+		rollbackErr := previous.apply(api)
+		api.policyMu.Unlock()
+		if rollbackErr != nil {
 			log.Error().Err(rollbackErr).Msg("roll back relay policy state")
 		}
 		utils.WriteAPIError(w, http.StatusInternalServerError, types.APIErrorCodeInternal, "policy could not be persisted")

--- a/cmd/relay-server/api.go
+++ b/cmd/relay-server/api.go
@@ -37,9 +37,8 @@ type RelayAPI struct {
 	frontendFS           fs.FS
 	frontendCache        sync.Map
 	frontendCacheEnabled bool
-	// policyWriteMu serializes policy mutations end to end, including the
-	// state-file write; policyMu only guards in-memory reads so readers never
-	// block on disk I/O.
+	// policyWriteMu serializes mutations including the state-file write;
+	// policyMu guards in-memory state only, so readers never block on disk I/O.
 	policyWriteMu      sync.Mutex
 	policyMu           sync.RWMutex
 	landingPageEnabled bool

--- a/cmd/relay-server/frontend.go
+++ b/cmd/relay-server/frontend.go
@@ -33,7 +33,7 @@ func resolveFrontendFS(frontendDir string) (fs.FS, error) {
 		var err error
 		frontendFS, err = fs.Sub(embeddedDistFS, embeddedFrontendRoot)
 		if err != nil {
-			return nil, fmt.Errorf("open embedded frontend (run 'make build-frontend' before building the relay server): %w", err)
+			return nil, fmt.Errorf("open embedded frontend: %w", err)
 		}
 	} else {
 		absDir, err := filepath.Abs(frontendDir)
@@ -47,7 +47,7 @@ func resolveFrontendFS(frontendDir string) (fs.FS, error) {
 	entry, err := fs.Stat(frontendFS, "index.html")
 	if err != nil {
 		if frontendDir == "" {
-			return nil, fmt.Errorf("embedded frontend is missing index.html; run 'make build-frontend' before building the relay server: %w", err)
+			return nil, fmt.Errorf("embedded frontend is missing index.html; run 'make build-frontend' first: %w", err)
 		}
 		return nil, fmt.Errorf("%s requires index.html: %w", frontendSource, err)
 	}
@@ -78,9 +78,7 @@ func (api *RelayAPI) serveFrontend(w http.ResponseWriter, r *http.Request) {
 	}
 	asset, err := api.loadFrontendAsset(assetPath)
 	if err != nil {
-		// Missing static assets (paths with a recognized file extension) must
-		// 404 instead of serving HTML with a wrong content type; only
-		// client-route-looking paths fall back to the SPA entry point.
+		// Missing static assets 404; only client-route-looking paths fall back.
 		if assetPath == "index.html" || mime.TypeByExtension(path.Ext(assetPath)) != "" {
 			http.NotFound(w, r)
 			return

--- a/cmd/relay-server/frontend.go
+++ b/cmd/relay-server/frontend.go
@@ -12,6 +12,8 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+
+	"github.com/gosuda/portal-tunnel/v2/types"
 )
 
 const embeddedFrontendRoot = "dist/app"
@@ -31,7 +33,7 @@ func resolveFrontendFS(frontendDir string) (fs.FS, error) {
 		var err error
 		frontendFS, err = fs.Sub(embeddedDistFS, embeddedFrontendRoot)
 		if err != nil {
-			return nil, fmt.Errorf("open embedded frontend: %w", err)
+			return nil, fmt.Errorf("open embedded frontend (run 'make build-frontend' before building the relay server): %w", err)
 		}
 	} else {
 		absDir, err := filepath.Abs(frontendDir)
@@ -44,6 +46,9 @@ func resolveFrontendFS(frontendDir string) (fs.FS, error) {
 
 	entry, err := fs.Stat(frontendFS, "index.html")
 	if err != nil {
+		if frontendDir == "" {
+			return nil, fmt.Errorf("embedded frontend is missing index.html; run 'make build-frontend' before building the relay server: %w", err)
+		}
 		return nil, fmt.Errorf("%s requires index.html: %w", frontendSource, err)
 	}
 	if !entry.Mode().IsRegular() {
@@ -60,7 +65,7 @@ func (api *RelayAPI) serveFrontend(w http.ResponseWriter, r *http.Request) {
 	}
 
 	requestPath := path.Clean("/" + strings.TrimSpace(r.URL.Path))
-	for _, prefix := range []string{"/api", "/sdk", "/discovery", "/v1"} {
+	for _, prefix := range types.ReservedRootPrefixes {
 		if requestPath == prefix || strings.HasPrefix(requestPath, prefix+"/") {
 			http.NotFound(w, r)
 			return
@@ -73,6 +78,13 @@ func (api *RelayAPI) serveFrontend(w http.ResponseWriter, r *http.Request) {
 	}
 	asset, err := api.loadFrontendAsset(assetPath)
 	if err != nil {
+		// Missing static assets (paths with a recognized file extension) must
+		// 404 instead of serving HTML with a wrong content type; only
+		// client-route-looking paths fall back to the SPA entry point.
+		if assetPath == "index.html" || mime.TypeByExtension(path.Ext(assetPath)) != "" {
+			http.NotFound(w, r)
+			return
+		}
 		assetPath = "index.html"
 		asset, err = api.loadFrontendAsset(assetPath)
 		if err != nil {
@@ -107,8 +119,10 @@ func (api *RelayAPI) serveFrontend(w http.ResponseWriter, r *http.Request) {
 }
 
 func (api *RelayAPI) loadFrontendAsset(assetPath string) (*frontendAsset, error) {
-	if cached, ok := api.frontendCache.Load(assetPath); ok {
-		return cached.(*frontendAsset), nil
+	if api.frontendCacheEnabled {
+		if cached, ok := api.frontendCache.Load(assetPath); ok {
+			return cached.(*frontendAsset), nil
+		}
 	}
 
 	data, err := fs.ReadFile(api.frontendFS, assetPath)
@@ -140,6 +154,9 @@ func (api *RelayAPI) loadFrontendAsset(assetPath string) (*frontendAsset, error)
 			return nil, err
 		}
 		asset.gzipData = compressed.Bytes()
+	}
+	if !api.frontendCacheEnabled {
+		return asset, nil
 	}
 	actual, _ := api.frontendCache.LoadOrStore(assetPath, asset)
 	return actual.(*frontendAsset), nil

--- a/cmd/relay-server/frontend_test.go
+++ b/cmd/relay-server/frontend_test.go
@@ -27,6 +27,20 @@ func TestServeFrontendFallsBackForDottedClientRoute(t *testing.T) {
 	}
 }
 
+func TestServeFrontendReturnsNotFoundForMissingAsset(t *testing.T) {
+	api := &RelayAPI{frontendFS: fstest.MapFS{
+		"index.html": {Data: []byte("<html>portal</html>")},
+	}}
+	recorder := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodGet, "/assets/app-oldhash.js", nil)
+
+	api.serveFrontend(recorder, request)
+
+	if recorder.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want %d", recorder.Code, http.StatusNotFound)
+	}
+}
+
 func TestServeFrontendDoesNotHandleReservedPortalPath(t *testing.T) {
 	api := &RelayAPI{frontendFS: fstest.MapFS{
 		"index.html": {Data: []byte("<html>portal</html>")},

--- a/types/paths.go
+++ b/types/paths.go
@@ -27,7 +27,8 @@ const (
 	X402VerifyPath      = PathX402Facilitator + "/verify"
 	X402SettlePath      = PathX402Facilitator + "/settle"
 
-	PathV1Sign = "/v1/sign"
+	PathV1Prefix = "/v1"
+	PathV1Sign   = PathV1Prefix + "/sign"
 
 	PathSDKPrefix            = "/sdk"
 	PathSDKDomain            = PathSDKPrefix + "/domain"
@@ -41,6 +42,10 @@ const (
 	PathDiscovery         = "/discovery"
 	PathDiscoveryAnnounce = PathDiscovery + "/announce"
 )
+
+// ReservedRootPrefixes are relay-owned root-host path trees that must never
+// be served by the SPA frontend fallback.
+var ReservedRootPrefixes = []string{PathAPIPrefix, PathSDKPrefix, PathDiscovery, PathV1Prefix}
 
 const (
 	X402PreparePath = "/x402/prepare"

--- a/types/paths.go
+++ b/types/paths.go
@@ -43,8 +43,7 @@ const (
 	PathDiscoveryAnnounce = PathDiscovery + "/announce"
 )
 
-// ReservedRootPrefixes are relay-owned root-host path trees that must never
-// be served by the SPA frontend fallback.
+// ReservedRootPrefixes are relay-owned root-host path trees never served by the SPA fallback.
 var ReservedRootPrefixes = []string{PathAPIPrefix, PathSDKPrefix, PathDiscovery, PathV1Prefix}
 
 const (


### PR DESCRIPTION
## Summary

Follow-up to the review comments on #289; targets `feature/tidy-build`.

- **Single owner for reserved paths**: `serveFrontend` no longer hardcodes `"/api", "/sdk", "/discovery", "/v1"`; the list now lives as `types.ReservedRootPrefixes` (with new `PathV1Prefix`), per the "shared public paths belong in `types/`" rule.
- **Missing static assets 404**: the SPA fallback only applies to client-route-looking paths. Paths whose extension resolves via `mime.TypeByExtension` (e.g. `/assets/app-oldhash.js` after a redeploy) now return 404 instead of `200 text/html`, which broke browsers with MIME errors. Dotted client routes like `/users/jane.doe` still fall back (existing test preserved; new test added).
- **Dir-backed frontend is no longer cached**: `frontendCacheEnabled` is true only for the embedded frontend. With `PORTAL_FRONTEND_DIR` set, assets are read from disk per request, so operators see file changes without restarting — consistent with the `no-cache` header on `index.html`.
- **Policy reads no longer block on disk I/O**: mutations serialize on a new `policyWriteMu` for the whole apply+persist sequence, while `policyMu` is held only around in-memory state:
  ```go
  policyWriteMu.Lock()            // serializes writers incl. file write
  policyMu.Lock(); previous, payload snapshot; policyMu.Unlock()
  persistPolicyState(previous, payload)  // disk write outside policyMu
  ```
  Rollback on persist failure re-takes `policyMu` briefly.
- **Clearer bootstrap failure**: the embedded-frontend-missing startup error now says to run `make build-frontend`.
- **One source of build flags**: `GO_BUILD_FLAGS` in the Makefile is shared by `build-tunnel`/`build-server-bin`, and the Dockerfile calls `make build-server-bin` instead of duplicating the `go build` invocation. `build` no longer redundantly lists `build-frontend` (already implied by `build-server`).

Not addressed here (design decisions for the author): the `TunnelCommandForm` full-lease-list polling and non-public lease visibility regression, and migration/release notes for the flipped `TRUST_PROXY_HEADERS`/`X402_ENABLED` defaults and removed images.

Verified with `go vet` and `go test ./cmd/relay-server/` (pre-commit golangci-lint/full also passed).

Link to Devin session: https://app.devin.ai/sessions/3ba3e627d55143b48d9efac275d169ad
Requested by: @metaphorics