### PR TITLE
Add agentic skills for portal-tunnel (dev workflow, CLIs, codebase map)

### DIFF
--- a/.agents/skills/codebase-map/SKILL.md
+++ b/.agents/skills/codebase-map/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: codebase-map
+description: Where things live in the portal-tunnel repo (sdk/portal/types/utils/cmd/discovery/x402/frontend/extensions) and where new code belongs. Use when locating functionality or deciding where to add code.
+---
+
+# portal-tunnel codebase map
+
+Portal is a zero-knowledge tunneling relay + local runtime: exposes local HTTP/TCP/UDP services through self-hosted or public relays with end-to-end tenant TLS, ECH SNI hiding, MITM self-probe, multi-hop routing, and x402 payments.
+
+## Top-level packages
+- `sdk/` — **client side**. Tunnel exposure and relay API client, listener/session management, HTTP routing + proxying, MITM detection. Entry points: `sdk/expose.go`, `sdk/listener.go`, `sdk/http.go`, `sdk/proxy.go`, `sdk/mitm.go`. x402 route protection is applied here (`sdk/http.go`).
+- `portal/` — **relay side**. API/server lifecycle (`portal/api_server.go`, `portal/server.go`), leases, proxying, identity, keyless TLS/ECH, overlay transports, policy, telemetry, ACME.
+  - `portal/discovery/` — relay gossip: `announce.go` (rate limiting), `refresher.go` (poll descriptors + `POST /discovery/announce` self-announce + peer refresh), `relayset.go` (validated pool, bans, route-planning state), `relaystate.go`, `mols.go` (route scoring).
+  - `portal/x402/` — payment gating: `handler.go`, `payment.go`, `casper.go`, `x402.go`, embedded browser `client.js`. Facilitator mounts at `/api/x402` only when `X402_ENABLED`.
+- `types/` — **shared contracts**: protocol/API/data models, identity & transport types, x402 types, and public path constants (`types/paths.go`). `types/types.go` unmarshals the embedded `config.toml`/`registry.json`. Put shared constants and public path strings HERE.
+- `utils/` — shared **stateless** helpers: API encoding, command dispatch (`utils/cmd.go`), files, paths, HTTP, name/network/TLS normalization, snapshots.
+- `cmd/` — executables: `cmd/portal-tunnel` (client CLI), `cmd/relay-server` (relay + embedded SPA), `cmd/portal-loadtest` (`make load-test`), plus demo/payment apps.
+- `frontend/` — React + Tailwind SPA (Vite). Built and embedded into the relay binary at `cmd/relay-server/dist/app` (`//go:embed dist/*`). Dev server at `http://localhost:5173`; point at a live relay with `VITE_PORTAL_API_BASE_URL`.
+- `docs/` — SvelteKit docs site (`make build-docs`, uses bun).
+- `extensions/vscode/` — VS Code extension (start/stop tunnel commands, relay/host/name settings).
+
+## Root files
+- `config.toml` — embedded release version + protocol versions (via `manifest.go`).
+- `registry.json` — embedded default public relay list → `types.BootstrapRelays`.
+- `manifest.go` — `//go:embed` of the two files above.
+- `docker-compose.yml` / `Dockerfile` — relay container build/deploy.
+
+## Where new code belongs (AGENTS.md)
+- Shared contract / constant / public path → `types/` (one owner, no duplication).
+- Stateless transform reused across packages → `utils/`.
+- Stateful/domain logic → its real owner in `sdk/` or `portal/` (resolve complexity in the lowest coherent owner, expose minimum surface).
+- Avoid speculative abstraction, wrappers with no boundary, and dead fields; remove stale code while nearby.

--- a/.agents/skills/dev-workflow/SKILL.md
+++ b/.agents/skills/dev-workflow/SKILL.md
@@ -1,0 +1,38 @@
+---
+name: dev-workflow
+description: Build, lint, test, and verification workflow for the portal-tunnel Go+frontend monorepo. Use when setting up the repo, running CI-equivalent checks, or before committing changes.
+---
+
+# portal-tunnel dev workflow
+
+## Toolchain
+- Go pinned to `go1.26.4` via `go.mod`; the Makefile exports `GOTOOLCHAIN=go1.26.4`, so `make` targets self-pin even on other Go installs.
+- `make install` installs the pinned dev tools: `goimports@v0.41.0` and `golangci-lint@v2.11.1` (into `$(go env GOPATH)/bin`, usually `~/go/bin` — put it on PATH).
+- Frontend build/test needs Node 22+.
+- `bun` is needed only for `make build-docs`.
+
+## Verification (CI commands, from AGENTS.md)
+Run these three before pushing; they are what CI enforces:
+```
+make vet     # go vet ./cmd/... ./portal/... ./sdk/... ./types/... ./utils/...
+make lint    # golangci-lint run (same package set)
+make test    # go test -coverprofile=coverage.out (same set) + `cd frontend && npm test` (vitest)
+```
+Per AGENTS.md, run tests only when needed/asked; `make tidy` is local maintenance, not a CI gate.
+
+## Pre-commit hooks
+`.pre-commit-config.yaml` runs whitespace/EOL/BOM fixers, golangci-lint (config-verify, `--new-from-rev HEAD --fix`, and full `--fix`), plus local `make fmt` and `go vet ./...`.
+- `make fmt` runs `gofmt -w .` then `goimports -w .`, so `goimports` MUST be on PATH or the commit hook fails with `goimports: No such file or directory` — run `make install` first.
+- Note the golangci-lint version differs between pre-commit (`v2.10.1`) and the Makefile (`v2.11.1`); expect minor lint-behavior drift.
+
+## Build
+- `make build` → `build-tunnel` + `build-server` (full artifacts).
+- `make build-frontend` builds the SPA (`cd frontend && npm ci && npm run build`) and copies `frontend/dist/.` into `cmd/relay-server/dist/app` (embedded by the relay via `//go:embed dist/*`).
+- `make build-server-bin` compiles only `bin/relay-server`; it assumes `dist/app` already exists (use after `build-frontend`, or the binary fails at startup asking you to run `make build-frontend`).
+- `make build-tunnel` cross-compiles `cmd/portal-tunnel` for linux/darwin/windows × amd64/arm64.
+- Shared Go build flags live in the Makefile var `GO_BUILD_FLAGS` (`-trimpath -ldflags "-s -w"`); the Dockerfile calls `make build-server-bin` rather than duplicating them.
+
+## Making changes (AGENTS.md conventions — enforce in review)
+- Shared contracts, constants, and **public path strings** belong in `types/` (e.g. `types/paths.go`), never duplicated in runtime/helpers.
+- Stateless shared transforms go in `utils/`; stateful/domain logic stays with its real owner (`sdk/` or `portal/`).
+- Prefer one owner per contract; no speculative abstraction, wrappers, or dead fields — remove them while touching nearby code.

--- a/.agents/skills/portal-tunnel-cli/SKILL.md
+++ b/.agents/skills/portal-tunnel-cli/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: portal-tunnel-cli
+description: How the portal-tunnel client CLI (cmd/portal-tunnel) is structured and invoked — expose/agent/list/update subcommands, flags, validation rules, and x402/routing options. Use when changing or testing client-side tunnel behavior.
+---
+
+# portal-tunnel client CLI
+
+Entrypoint `cmd/portal-tunnel/main.go`. Subcommands are dispatched by the repo's own `utils.RunCommands` (std `flag` package, NOT cobra/urfave). Commands: `expose`, `agent {run,dashboard,stop,restart}`, `list`, `update`, `version`, `help`. Flags are defined in code (`main.go`, `agent.go`); `--help` prints usage + examples but does NOT enumerate flags — read the source for the authoritative list.
+
+## expose (main.go ~85-110)
+Publishes a local service. Key flags (many have env fallbacks, shown in `ENV`):
+- Target: positional `<target>` (e.g. `3000`, `localhost:8080`) OR `--http-route "PATH=UPSTREAM[ METHOD,...:AMOUNT]"` (repeatable) OR `--serve <dir|file>` for static.
+- Relays: `--relays` (extra API URLs), `--discovery` (default true), `--max-active-relays` (default 3, `MAX_ACTIVE_RELAYS`).
+- Multi-hop: `--multi-hop` (explicit ordered URLs, `MULTI_HOP`) OR `--multi-hop-depth` (default 0, `MULTI_HOP_DEPTH`) — mutually exclusive.
+- Identity: `--identity-path` (default `identity.json`, `IDENTITY_PATH`), `--identity-json` (`IDENTITY_JSON`).
+- MITM: `--ban-mitm` (`BAN_MITM`).
+- Transport: `--udp`/`--udp-addr` (`UDP_ENABLED`/`UDP_ADDR`), `--tcp` (`TCP_ENABLED`).
+- Metadata: `--name --description --tags --owner --thumbnail --hide`.
+- x402: `--x402-pay-to`, `--x402-network` (Sui/Casper CAIP-2), `--x402-asset`, `--x402-testnet`, `--x402-endpoint` (repeatable), `--x402-facilitator-token` (`CSPR_CLOUD_API_KEY`).
+- `--metrics-addr`. Parsed values flow into `sdk.ExposeConfig` (main.go ~224-281).
+
+### Validation rules (must hold; see main.go ~125-148)
+- positional target cannot combine with `--http-route`.
+- `--serve` cannot combine with target/`--http-route`/`--udp`/`--tcp`.
+- `--http-route` payment amounts require `--x402-pay-to`.
+- Casper networks require `--x402-asset`.
+- `--multi-hop` cannot combine with `--multi-hop-depth`.
+
+### Examples
+```
+portal expose 3000
+portal expose localhost:8080 --name my-app
+portal expose --serve ./site --name my-app
+portal expose --http-route /api=http://127.0.0.1:3001 --http-route /=http://127.0.0.1:5173
+portal expose 3000 --udp --udp-addr 127.0.0.1:5353
+portal expose 3000 --relays https://portal.example.com --discovery=false
+portal expose 3000 --multi-hop-depth 3
+```
+
+## Other commands
+- `agent run` (`--config` default `service.DefaultConfigPath()`, `--service`, `--foreground`); `agent dashboard`/`stop` (`--config`, `--state-dir`); `agent restart` (`--config`). See `cmd/portal-tunnel/agent.go`.
+- `list` (`--relays`, `--default-relays` default true).
+- `update` (`--version`, empty = latest).
+
+## Defaults source
+Default public relays come from embedded `registry.json` → `types.BootstrapRelays`; version/protocol from `config.toml` → `types.ReleaseVersion`/`SDKVersion`/`DiscoveryVersion` (embedded via `manifest.go`).

--- a/.agents/skills/relay-server-config/SKILL.md
+++ b/.agents/skills/relay-server-config/SKILL.md
@@ -1,0 +1,41 @@
+---
+name: relay-server-config
+description: Full environment-variable / flag reference for configuring the portal-tunnel relay-server (cmd/relay-server), plus how config is embedded and how Docker/Compose deploys it. Use when configuring, deploying, or debugging a relay.
+---
+
+# relay-server configuration
+
+Entrypoint `cmd/relay-server/main.go`, dispatched by `utils.RunCommands` (`""`/`serve` → serve, `help`). Every flag has an env fallback parsed by `utils.{String,Bool,Int}FlagEnv` at flag-init time (`utils/cmd.go`); flags are declared in `main.go ~79-117`. `--help` shows usage/examples only, not flags.
+
+## Core env vars / flags (default)
+| Env | Default | Purpose |
+|---|---|---|
+| `PORTAL_URL` | `https://localhost` | portal base URL (`--portal-url`) |
+| `PORTAL_FRONTEND_DIR` | empty | custom SPA dir; empty = embedded (`--frontend-dir`) |
+| `IDENTITY_PATH` | `./.portal-certs` | identity/cert + `policy.json` dir (`--identity-path`) |
+| `API_PORT` | `4017` | HTTPS API + frontend (`--api-port`) |
+| `SNI_PORT` | `443` | public SNI ingress (`--sni-port`) — cannot bind unprivileged; override locally |
+| `WIREGUARD_PORT` | `51820` | (`--wireguard-port`) |
+| `ADMIN_TOKEN` | empty | bearer token for admin/policy APIs (`--admin-token`) |
+| `LANDING_PAGE_ENABLED` | `false` | (`--landing-page-enabled`) |
+| `DISCOVERY` | `false` | enable gossip; needs `BOOTSTRAPS` (`--discovery`) |
+| `BOOTSTRAPS` | empty | comma-separated bootstrap relay URLs (`--bootstraps`) |
+| `TRUST_PROXY_HEADERS` | `false` | trust XFF etc. (`--trust-proxy-headers`) |
+| `TRUSTED_PROXY_CIDRS` | empty | (`--trusted-proxy-cidrs`) |
+| `UDP_ENABLED` / `TCP_ENABLED` | `false` | non-HTTP lease transports |
+| `MIN_PORT` / `MAX_PORT` | `0` / `0` | lease port range; `0` disables |
+| `PPROF_ENABLED` / `PPROF_ADDR` | `false` / `127.0.0.1:6060` | pprof |
+| `X402_ENABLED` / `X402_TESTNET` / `X402_PAY_TO` | `false` / `false` / empty | mounts facilitator under `/api/x402` only when enabled |
+
+DNS/ACME provider creds are also env-bound: `ACME_DNS_PROVIDER`, `CLOUDFLARE_TOKEN`, GCP (`GCP_PROJECT_ID`+aliases, `GCP_MANAGED_ZONE`+aliases), Hetzner (`HETZNER_API_TOKEN`/`HCLOUD_TOKEN`), AWS Route53 (`AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY`/`AWS_SESSION_TOKEN`/`AWS_REGION`→defaults us-east-1 downstream/`AWS_HOSTED_ZONE_ID`/`AWS_DNSSEC_KMS_KEY_ARN`), `VULTR_API_KEY`, `NJALLA_TOKEN`, `ENS_GASLESS_ENABLED`. Never hardcode these — reference as env vars / secrets.
+
+## Reserved API surface (types/paths.go)
+Root-host trees that must never fall through to the SPA: `types.ReservedRootPrefixes` = `/api`, `/sdk`, `/discovery`, `/v1`. x402 public paths `/x402/prepare`, `/x402/client.js`; relay facilitator `/api/x402/{supported,verify,settle}`. Discovery: `/discovery`, `/discovery/announce` (only when `DISCOVERY=true`).
+
+## Admin/policy API
+`GET/POST /api/policy` with `Authorization: Bearer $ADMIN_TOKEN`. POST requires the FULL settings object (partial bodies → 400 `invalid_mode`). Persists to `$IDENTITY_PATH/policy.json`.
+
+## Config embedding & Docker
+- `config.toml` (version/protocol) and `registry.json` (default relays) are embedded via `manifest.go` and parsed in `types/types.go`.
+- `docker-compose.yml` runs `ghcr.io/gosuda/portal:2`, publishes TCP 443 + UDP WireGuard port, and passes the above env vars.
+- `Dockerfile`: Node 22 stage builds the frontend into `cmd/relay-server/dist/app`, then `make build-server-bin` compiles the Go relay.


### PR DESCRIPTION
Four new skills under .agents/skills/ to help future agents work in this repo: dev-workflow, portal-tunnel-cli, relay-server-config, and codebase-map. All facts verified against the Makefile, CLI --help/source, types/paths.go, config/embedding, and AGENTS.md. Complements the existing testing-relay-server skill.

Devin Session: https://app.devin.ai/sessions/3ba3e627d55143b48d9efac275d169ad