### PR TITLE
feat: make ECH optional for stream tunnels

### DIFF
--- a/cmd/portal-tunnel/agent/config.go
+++ b/cmd/portal-tunnel/agent/config.go
@@ -50,6 +50,7 @@ type TunnelConfig struct {
 	UDPEnabled           bool              `koanf:"udp"`
 	UDPAddr              string            `koanf:"udp_addr"`
 	TCPEnabled           bool              `koanf:"tcp"`
+	ECH                  bool              `koanf:"ech"`
 	MultiHop             []string          `koanf:"multi_hop"`
 	MultiHopDepth        int               `koanf:"multi_hop_depth"`
 	BanMITM              *bool             `koanf:"ban_mitm"`
@@ -203,6 +204,9 @@ func tunnelConfigDocumentMap(cfg TunnelConfig) map[string]any {
 	addStringDocumentField(out, "udp_addr", cfg.UDPAddr)
 	if cfg.TCPEnabled {
 		out["tcp"] = cfg.TCPEnabled
+	}
+	if cfg.ECH {
+		out["ech"] = cfg.ECH
 	}
 	addStringSliceDocumentField(out, "multi_hop", cfg.MultiHop)
 	if cfg.MultiHopDepth != 0 {

--- a/cmd/portal-tunnel/agent/manager.go
+++ b/cmd/portal-tunnel/agent/manager.go
@@ -717,6 +717,7 @@ func (t *managedTunnel) runOnce(ctx context.Context) error {
 		UDPAddr:              cfg.UDPAddr,
 		UDPEnabled:           cfg.UDPEnabled,
 		TCPEnabled:           cfg.TCPEnabled,
+		ECH:                  cfg.ECH,
 		MultiHop:             append([]string(nil), cfg.MultiHop...),
 		MultiHopDepth:        cfg.MultiHopDepth,
 		BanMITM:              banMITM,

--- a/cmd/portal-tunnel/main.go
+++ b/cmd/portal-tunnel/main.go
@@ -72,6 +72,7 @@ type exposeFlags struct {
 	udp                  bool
 	udpAddr              string
 	tcp                  bool
+	ech                  bool
 	maxActiveRelays      int
 	multiHopDepth        int
 	metricsAddr          string
@@ -106,6 +107,7 @@ func runExposeCommand(args []string) error {
 	utils.BoolFlagEnv(fs, &flags.udp, "udp", false, "Enable public UDP relay in addition to the default TCP relay", "UDP_ENABLED")
 	utils.StringFlagEnv(fs, &flags.udpAddr, "udp-addr", "", "Local UDP target address for relayed datagrams (host:port or port only); defaults to the target when --udp is enabled", "UDP_ADDR")
 	utils.BoolFlagEnv(fs, &flags.tcp, "tcp", false, "Request a dedicated TCP port on the relay for raw TCP services (no TLS; e.g., Minecraft, game servers)", "TCP_ENABLED")
+	utils.BoolFlagEnv(fs, &flags.ech, "ech", false, "Enable Encrypted Client Hello hostname privacy for stream tunnels", "ECH_ENABLED")
 	utils.IntFlagEnv(fs, &flags.maxActiveRelays, "max-active-relays", 3, nil, "Maximum auto-selected single-hop relays to keep connected; multi-hop uses every eligible relay as an entry", "MAX_ACTIVE_RELAYS")
 	utils.IntFlagEnv(fs, &flags.multiHopDepth, "multi-hop-depth", 0, nil, "Automatically create multi-hop routes at this hop count for every eligible entry relay; 0 or 1 disables multi-hop", "MULTI_HOP_DEPTH")
 	utils.StringFlag(fs, &flags.metricsAddr, "metrics-addr", "", "Optional address (host:port) to serve Prometheus /metrics. Empty = disabled.")
@@ -232,6 +234,7 @@ func runExposeCommand(args []string) error {
 		UDPAddr:         flags.udpAddr,
 		UDPEnabled:      flags.udp,
 		TCPEnabled:      flags.tcp,
+		ECH:             flags.ech,
 		MultiHop:        utils.SplitCSV(flags.multiHopCSV),
 		MultiHopDepth:   flags.multiHopDepth,
 		BanMITM:         flags.banMITM,

--- a/portal/acme/acme.go
+++ b/portal/acme/acme.go
@@ -12,6 +12,7 @@ import (
 	"encoding/pem"
 	"errors"
 	"fmt"
+	mathrand "math/rand/v2"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -43,6 +44,8 @@ const (
 	defaultRenewInterval        = 24 * time.Hour
 	defaultDNSSyncInterval      = 10 * time.Minute
 	defaultSyncTimeout          = 2 * time.Minute
+	defaultECHRetryBase         = time.Second
+	defaultECHRetryMax          = 10 * time.Minute
 )
 
 type Config struct {
@@ -70,6 +73,7 @@ type Manager struct {
 	cfg           Config
 	wg            sync.WaitGroup
 	dns           DNSProvider
+	resolveIPv4   func(context.Context) (string, error)
 	startOnce     sync.Once
 	stopOnce      sync.Once
 	dnssecLogOnce sync.Once
@@ -77,7 +81,21 @@ type Manager struct {
 	ensStatus     *utils.Snapshot[types.ENSStatus]
 	trackedMu     sync.Mutex
 	echMu         sync.Mutex
-	echRecords    map[string]HTTPSRecord
+	echRecords    map[string]*echDNSState
+}
+
+// echDNSState is the desired DNS state for one public hostname. Operations on
+// the same hostname are serialized so an older delete cannot overtake a newer
+// create or update.
+type echDNSState struct {
+	mu             sync.Mutex
+	record         HTTPSRecord
+	present        bool
+	dirty          bool
+	httpsDeleted   bool
+	retryFailures  int
+	retryScheduled bool
+	retryWake      chan struct{}
 }
 
 type HTTPSRecord struct {
@@ -186,16 +204,18 @@ func NewManager(cfg Config) (*Manager, error) {
 	}
 	if utils.IsLocalRelayHost(cfg.BaseDomain) {
 		return &Manager{
-			cfg:       cfg,
-			stopCh:    make(chan struct{}),
-			ensStatus: utils.NewSnapshot(newENSStatus(cfg, nil)),
+			cfg:         cfg,
+			stopCh:      make(chan struct{}),
+			ensStatus:   utils.NewSnapshot(newENSStatus(cfg, nil)),
+			resolveIPv4: utils.ResolvePublicIPv4,
 		}, nil
 	}
 
 	manager := &Manager{
-		cfg:       cfg,
-		stopCh:    make(chan struct{}),
-		ensStatus: utils.NewSnapshot(newENSStatus(cfg, nil)),
+		cfg:         cfg,
+		stopCh:      make(chan struct{}),
+		ensStatus:   utils.NewSnapshot(newENSStatus(cfg, nil)),
+		resolveIPv4: utils.ResolvePublicIPv4,
 	}
 
 	acmeDNS, err := NewDNSProvider(cfg.DNSProvider, cfg)
@@ -466,7 +486,7 @@ func (m *Manager) maintenanceLoop(ctx context.Context) {
 			return
 		case <-dnsTicker.C:
 			syncCtx, cancel := context.WithTimeout(ctx, defaultSyncTimeout)
-			err := errors.Join(m.syncDNS(syncCtx), m.syncECHRecords(syncCtx))
+			err := m.syncDNS(syncCtx)
 			cancel()
 			if err != nil {
 				log.Warn().Err(err).Str("base_domain", m.cfg.BaseDomain).Msg("sync dns records")
@@ -501,7 +521,11 @@ func (m *Manager) syncDNS(ctx context.Context) error {
 		return nil
 	}
 
-	publicIP, err := utils.ResolvePublicIPv4(ctx)
+	resolveIPv4 := m.resolveIPv4
+	if resolveIPv4 == nil {
+		resolveIPv4 = utils.ResolvePublicIPv4
+	}
+	publicIP, err := resolveIPv4(ctx)
 	if err != nil {
 		return fmt.Errorf("detect public ip: %w", err)
 	}
@@ -537,31 +561,27 @@ func (m *Manager) SyncECHConfig(ctx context.Context, hostname string, echConfigL
 	if err != nil {
 		return err
 	}
-	content, err := record.Content()
-	if err != nil {
-		return err
-	}
-	svcParams := record.SvcParams()
-
 	m.echMu.Lock()
 	if m.echRecords == nil {
-		m.echRecords = make(map[string]HTTPSRecord)
+		m.echRecords = make(map[string]*echDNSState)
 	}
-	m.echRecords[hostname] = record
+	state := m.echRecords[hostname]
+	if state == nil {
+		state = &echDNSState{retryWake: make(chan struct{}, 1)}
+		m.echRecords[hostname] = state
+	}
+	state.mu.Lock()
 	m.echMu.Unlock()
 
-	publicIP, err := utils.ResolvePublicIPv4(ctx)
-	if err != nil {
-		return fmt.Errorf("detect public ip for ECH hostname %s: %w", hostname, err)
-	}
-	if err := m.dns.EnsureARecord(ctx, hostname, publicIP); err != nil {
-		return fmt.Errorf("ensure ECH A record for %s: %w", hostname, err)
-	}
-
-	if err := m.dns.EnsureHTTPSRecord(ctx, hostname, record.Priority, record.Target, svcParams, content); err != nil {
-		return err
-	}
-	return nil
+	defer state.mu.Unlock()
+	state.record = record
+	state.present = true
+	state.dirty = true
+	state.httpsDeleted = false
+	err = m.syncECHState(ctx, hostname, state)
+	state.dirty = err != nil
+	m.updateECHRetry(hostname, state, err)
+	return err
 }
 
 func (m *Manager) DeleteECHConfig(ctx context.Context, hostname string) error {
@@ -579,57 +599,186 @@ func (m *Manager) DeleteECHConfig(ctx context.Context, hostname string) error {
 		return nil
 	}
 
-	if err := m.dns.DeleteHTTPSRecord(ctx, hostname); err != nil {
-		return err
-	}
-	if hostname != m.cfg.BaseDomain {
-		if err := m.dns.DeleteARecord(ctx, hostname); err != nil {
-			return fmt.Errorf("delete ECH A record for %s: %w", hostname, err)
-		}
-	}
-
 	m.echMu.Lock()
-	delete(m.echRecords, hostname)
+	if m.echRecords == nil {
+		m.echRecords = make(map[string]*echDNSState)
+	}
+	state := m.echRecords[hostname]
+	if state == nil {
+		state = &echDNSState{retryWake: make(chan struct{}, 1)}
+		m.echRecords[hostname] = state
+	}
+	state.mu.Lock()
 	m.echMu.Unlock()
-	return nil
+
+	if state.present {
+		state.httpsDeleted = false
+	}
+	state.present = false
+	state.dirty = true
+	err := m.syncECHState(ctx, hostname, state)
+	state.dirty = err != nil
+	m.updateECHRetry(hostname, state, err)
+	state.mu.Unlock()
+	if err == nil {
+		m.removeECHState(hostname, state)
+	}
+	return err
 }
 
-func (m *Manager) syncECHRecords(ctx context.Context) error {
-	if m == nil || m.dns == nil || utils.IsLocalRelayHost(m.cfg.BaseDomain) {
+func (m *Manager) syncECHState(ctx context.Context, hostname string, state *echDNSState) error {
+	if !state.present {
+		if !state.httpsDeleted {
+			err := m.dns.DeleteHTTPSRecord(ctx, hostname)
+			if err != nil {
+				return err
+			}
+			state.httpsDeleted = true
+		}
+		if hostname != m.cfg.BaseDomain {
+			err := m.dns.DeleteARecord(ctx, hostname)
+			if err != nil {
+				return fmt.Errorf("delete ECH A record for %s: %w", hostname, err)
+			}
+		}
 		return nil
 	}
 
-	m.echMu.Lock()
-	records := make(map[string]HTTPSRecord, len(m.echRecords))
-	for hostname, record := range m.echRecords {
-		records[hostname] = record
+	publicIP, err := utils.ResolvePublicIPv4(ctx)
+	if err != nil {
+		return fmt.Errorf("detect public ip for ECH hostname %s: %w", hostname, err)
 	}
-	m.echMu.Unlock()
+	err = m.dns.EnsureARecord(ctx, hostname, publicIP)
+	if err != nil {
+		return fmt.Errorf("ensure ECH A record for %s: %w", hostname, err)
+	}
+	content, err := state.record.Content()
+	if err != nil {
+		return fmt.Errorf("build ECH HTTPS record for %s: %w", hostname, err)
+	}
+	err = m.dns.EnsureHTTPSRecord(ctx, hostname, state.record.Priority, state.record.Target, state.record.SvcParams(), content)
+	if err != nil {
+		return fmt.Errorf("ensure ECH HTTPS record for %s: %w", hostname, err)
+	}
+	return nil
+}
 
-	var syncErr error
-	publicIP := ""
-	if len(records) > 0 {
-		var err error
-		publicIP, err = utils.ResolvePublicIPv4(ctx)
-		if err != nil {
-			return fmt.Errorf("detect public ip for ECH records: %w", err)
+func (m *Manager) updateECHRetry(hostname string, state *echDNSState, err error) {
+	if err == nil {
+		state.retryFailures = 0
+		if state.retryScheduled {
+			select {
+			case state.retryWake <- struct{}{}:
+			default:
+			}
 		}
+		return
 	}
-	for hostname, record := range records {
-		if err := m.dns.EnsureARecord(ctx, hostname, publicIP); err != nil {
-			syncErr = errors.Join(syncErr, fmt.Errorf("ensure ECH A record for %s: %w", hostname, err))
-			continue
+	state.retryFailures++
+	if state.retryScheduled {
+		select {
+		case state.retryWake <- struct{}{}:
+		default:
 		}
-		content, err := record.Content()
-		if err != nil {
-			syncErr = errors.Join(syncErr, fmt.Errorf("build ECH HTTPS record for %s: %w", hostname, err))
-			continue
-		}
-		if err := m.dns.EnsureHTTPSRecord(ctx, hostname, record.Priority, record.Target, record.SvcParams(), content); err != nil {
-			syncErr = errors.Join(syncErr, fmt.Errorf("ensure ECH HTTPS record for %s: %w", hostname, err))
-		}
+		return
 	}
-	return syncErr
+	state.retryScheduled = true
+	go m.retryECHState(hostname, state)
+}
+
+func (m *Manager) retryECHState(hostname string, state *echDNSState) {
+	for {
+		state.mu.Lock()
+		if !state.dirty {
+			state.retryScheduled = false
+			remove := !state.present
+			state.mu.Unlock()
+			if remove {
+				m.removeECHState(hostname, state)
+			}
+			return
+		}
+		delay := echRetryDelay(state.retryFailures)
+		state.mu.Unlock()
+
+		timer := time.NewTimer(delay)
+		select {
+		case <-m.stopCh:
+			timer.Stop()
+			state.mu.Lock()
+			state.retryScheduled = false
+			state.mu.Unlock()
+			return
+		case <-state.retryWake:
+			timer.Stop()
+			continue
+		case <-timer.C:
+		}
+
+		ctx, cancel := context.WithTimeout(context.Background(), defaultSyncTimeout)
+		state.mu.Lock()
+		if !state.dirty {
+			state.retryScheduled = false
+			remove := !state.present
+			state.mu.Unlock()
+			cancel()
+			if remove {
+				m.removeECHState(hostname, state)
+			}
+			return
+		}
+		err := m.syncECHState(ctx, hostname, state)
+		state.dirty = err != nil
+		failures := 0
+		if err == nil {
+			state.retryFailures = 0
+			state.retryScheduled = false
+		} else {
+			state.retryFailures++
+			failures = state.retryFailures
+		}
+		remove := err == nil && !state.present
+		state.mu.Unlock()
+		cancel()
+
+		if err == nil {
+			if remove {
+				m.removeECHState(hostname, state)
+			}
+			return
+		}
+		log.Warn().
+			Err(err).
+			Str("hostname", hostname).
+			Int("retry_failures", failures).
+			Msg("retry ech dns operation")
+	}
+}
+
+func (m *Manager) removeECHState(hostname string, state *echDNSState) {
+	m.echMu.Lock()
+	state.mu.Lock()
+	if m.echRecords[hostname] == state && !state.present && !state.dirty && !state.retryScheduled {
+		delete(m.echRecords, hostname)
+	}
+	state.mu.Unlock()
+	m.echMu.Unlock()
+}
+
+func echRetryDelay(failures int) time.Duration {
+	delay := defaultECHRetryBase
+	for i := 1; i < failures; i++ {
+		if delay >= defaultECHRetryMax/2 {
+			delay = defaultECHRetryMax
+			break
+		}
+		delay *= 2
+	}
+	if delay > defaultECHRetryMax {
+		delay = defaultECHRetryMax
+	}
+	half := delay / 2
+	return half + time.Duration(mathrand.Int64N(int64(half)+1))
 }
 
 func (m *Manager) syncENSGasless(ctx context.Context) error {

--- a/portal/acme/acme_test.go
+++ b/portal/acme/acme_test.go
@@ -8,13 +8,272 @@ import (
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/pem"
+	"errors"
 	"math/big"
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"time"
+
+	"github.com/go-acme/lego/v4/challenge"
+
+	"github.com/gosuda/portal-tunnel/v2/portal/keyless"
 )
+
+type echTestDNSProvider struct {
+	mu sync.Mutex
+
+	failEnsureA     int
+	failEnsureHTTPS int
+	failDeleteA     int
+
+	ensureHTTPSCalls int
+	deleteHTTPSCalls int
+	deleteACalls     int
+
+	ensureHTTPSDone chan struct{}
+	deleteADone     chan struct{}
+	deleteStarted   chan struct{}
+	deleteBlock     chan struct{}
+	deleteStartOnce sync.Once
+}
+
+func (*echTestDNSProvider) Name() string { return "test" }
+func (*echTestDNSProvider) ChallengeProvider(context.Context) (challenge.Provider, error) {
+	return nil, nil
+}
+func (*echTestDNSProvider) EnsureARecords(context.Context, string, string) error { return nil }
+func (p *echTestDNSProvider) EnsureARecord(context.Context, string, string) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.failEnsureA > 0 {
+		p.failEnsureA--
+		return errors.New("ensure A failed")
+	}
+	return nil
+}
+func (p *echTestDNSProvider) DeleteARecord(context.Context, string) error {
+	p.mu.Lock()
+	p.deleteACalls++
+	if p.failDeleteA > 0 {
+		p.failDeleteA--
+		p.mu.Unlock()
+		return errors.New("delete A failed")
+	}
+	done := p.deleteADone
+	p.mu.Unlock()
+	if done != nil {
+		select {
+		case done <- struct{}{}:
+		default:
+		}
+	}
+	return nil
+}
+func (*echTestDNSProvider) EnsureTXTRecord(context.Context, string, string) error  { return nil }
+func (*echTestDNSProvider) DeleteTXTRecords(context.Context, string, string) error { return nil }
+func (p *echTestDNSProvider) EnsureHTTPSRecord(context.Context, string, uint16, string, string, string) error {
+	p.mu.Lock()
+	p.ensureHTTPSCalls++
+	if p.failEnsureHTTPS > 0 {
+		p.failEnsureHTTPS--
+		p.mu.Unlock()
+		return errors.New("ensure HTTPS failed")
+	}
+	done := p.ensureHTTPSDone
+	p.mu.Unlock()
+	if done != nil {
+		select {
+		case done <- struct{}{}:
+		default:
+		}
+	}
+	return nil
+}
+func (p *echTestDNSProvider) DeleteHTTPSRecord(ctx context.Context, _ string) error {
+	p.mu.Lock()
+	p.deleteHTTPSCalls++
+	started := p.deleteStarted
+	block := p.deleteBlock
+	p.mu.Unlock()
+	if started != nil {
+		p.deleteStartOnce.Do(func() { close(started) })
+	}
+	if block != nil {
+		select {
+		case <-block:
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+	return nil
+}
+func (*echTestDNSProvider) EnsureDNSSEC(context.Context, string) (string, string, string, error) {
+	return "", "", "", nil
+}
+
+func newECHTestManager(provider DNSProvider) *Manager {
+	return &Manager{
+		cfg:         Config{BaseDomain: "example.com"},
+		dns:         provider,
+		stopCh:      make(chan struct{}),
+		resolveIPv4: func(context.Context) (string, error) { return "203.0.113.10", nil },
+	}
+}
+
+func testECHConfigList(t *testing.T, hostname string) []byte {
+	t.Helper()
+	_, configList, err := keyless.EncryptedClientHelloMaterials("test seed", hostname)
+	if err != nil {
+		t.Fatalf("EncryptedClientHelloMaterials() error = %v", err)
+	}
+	return configList
+}
+
+func waitECHTestSignal(t *testing.T, signal <-chan struct{}) {
+	t.Helper()
+	select {
+	case <-signal:
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for ECH DNS operation")
+	}
+}
+
+func TestECHRetryDelayUsesBoundedExponentialBackoff(t *testing.T) {
+	for failures, upper := range []time.Duration{
+		time.Second,
+		2 * time.Second,
+		4 * time.Second,
+		8 * time.Second,
+	} {
+		delay := echRetryDelay(failures + 1)
+		if delay < upper/2 || delay > upper {
+			t.Fatalf("echRetryDelay(%d) = %v, want jittered range [%v, %v]", failures+1, delay, upper/2, upper)
+		}
+	}
+	delay := echRetryDelay(100)
+	if delay < defaultECHRetryMax/2 || delay > defaultECHRetryMax {
+		t.Fatalf("echRetryDelay(100) = %v, want bounded range [%v, %v]", delay, defaultECHRetryMax/2, defaultECHRetryMax)
+	}
+}
+
+func TestECHDNSRetriesCreateAndUpdate(t *testing.T) {
+	provider := &echTestDNSProvider{
+		failEnsureA:     1,
+		ensureHTTPSDone: make(chan struct{}, 1),
+	}
+	manager := newECHTestManager(provider)
+	defer manager.Stop()
+	hostname := "tunnel.example.com"
+	configList := testECHConfigList(t, hostname)
+
+	if err := manager.SyncECHConfig(context.Background(), hostname, configList, 443); err == nil {
+		t.Fatal("SyncECHConfig(create) error = nil, want provider failure")
+	}
+	waitECHTestSignal(t, provider.ensureHTTPSDone)
+
+	provider.mu.Lock()
+	provider.failEnsureHTTPS = 1
+	provider.mu.Unlock()
+	if err := manager.SyncECHConfig(context.Background(), hostname, configList, 8443); err == nil {
+		t.Fatal("SyncECHConfig(update) error = nil, want provider failure")
+	}
+	waitECHTestSignal(t, provider.ensureHTTPSDone)
+}
+
+func TestECHDNSDeleteRetryResumesAndRemovesState(t *testing.T) {
+	provider := &echTestDNSProvider{deleteADone: make(chan struct{}, 1)}
+	manager := newECHTestManager(provider)
+	defer manager.Stop()
+	hostname := "tunnel.example.com"
+	if err := manager.SyncECHConfig(context.Background(), hostname, testECHConfigList(t, hostname), 443); err != nil {
+		t.Fatalf("SyncECHConfig() error = %v", err)
+	}
+	provider.mu.Lock()
+	provider.failDeleteA = 1
+	provider.mu.Unlock()
+
+	if err := manager.DeleteECHConfig(context.Background(), hostname); err == nil {
+		t.Fatal("DeleteECHConfig() error = nil, want provider failure")
+	}
+	waitECHTestSignal(t, provider.deleteADone)
+
+	provider.mu.Lock()
+	deleteHTTPSCalls := provider.deleteHTTPSCalls
+	deleteACalls := provider.deleteACalls
+	provider.mu.Unlock()
+	if deleteHTTPSCalls != 1 {
+		t.Fatalf("DeleteHTTPSRecord() calls = %d, want 1", deleteHTTPSCalls)
+	}
+	if deleteACalls != 2 {
+		t.Fatalf("DeleteARecord() calls = %d, want 2", deleteACalls)
+	}
+	deadline := time.Now().Add(time.Second)
+	for {
+		manager.echMu.Lock()
+		_, exists := manager.echRecords[hostname]
+		manager.echMu.Unlock()
+		if !exists {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("ECH DNS state remains after successful delete retry")
+		}
+		time.Sleep(time.Millisecond)
+	}
+}
+
+func TestECHDNSStaleDeleteCannotRemoveNewCreate(t *testing.T) {
+	provider := &echTestDNSProvider{
+		deleteStarted: make(chan struct{}),
+		deleteBlock:   make(chan struct{}),
+	}
+	manager := newECHTestManager(provider)
+	defer manager.Stop()
+	hostname := "tunnel.example.com"
+	configList := testECHConfigList(t, hostname)
+	if err := manager.SyncECHConfig(context.Background(), hostname, configList, 443); err != nil {
+		t.Fatalf("SyncECHConfig(initial) error = %v", err)
+	}
+
+	deleteDone := make(chan error, 1)
+	go func() { deleteDone <- manager.DeleteECHConfig(context.Background(), hostname) }()
+	<-provider.deleteStarted
+	createDone := make(chan error, 1)
+	go func() { createDone <- manager.SyncECHConfig(context.Background(), hostname, configList, 8443) }()
+	deadline := time.Now().Add(time.Second)
+	for manager.echMu.TryLock() {
+		manager.echMu.Unlock()
+		if time.Now().After(deadline) {
+			t.Fatal("replacement create did not acquire ECH state map lock")
+		}
+		time.Sleep(time.Millisecond)
+	}
+	close(provider.deleteBlock)
+	if err := <-deleteDone; err != nil {
+		t.Fatalf("DeleteECHConfig() error = %v", err)
+	}
+	if err := <-createDone; err != nil {
+		t.Fatalf("SyncECHConfig(replacement) error = %v", err)
+	}
+
+	manager.echMu.Lock()
+	state := manager.echRecords[hostname]
+	if state != nil {
+		state.mu.Lock()
+	}
+	manager.echMu.Unlock()
+	if state == nil {
+		t.Fatal("replacement ECH DNS state was removed by stale delete")
+	}
+	present := state.present
+	state.mu.Unlock()
+	if !present {
+		t.Fatal("replacement ECH DNS state is not present")
+	}
+}
 
 func TestEnsureCertificateGeneratesLocalDevelopmentMaterial(t *testing.T) {
 	t.Parallel()

--- a/portal/lease_test.go
+++ b/portal/lease_test.go
@@ -95,6 +95,27 @@ func TestLeaseRegistryLifecycle(t *testing.T) {
 	}
 }
 
+func TestLeaseRegistryStreamDefaultsToPlainSNI(t *testing.T) {
+	t.Parallel()
+
+	registry := newTestRegistry(t)
+	record, _, err := registry.Register(types.RegisterChallengeRequest{
+		Identity: newTestLeaseIdentity(t, "plain-sni"),
+	}, "203.0.113.10", "")
+	if err != nil {
+		t.Fatalf("Register() error = %v", err)
+	}
+	if record.Hostname != "plain-sni.example.com" {
+		t.Fatalf("Register() hostname = %q, want public hostname", record.Hostname)
+	}
+	if record.HostnameHash != "" || len(record.ECHConfigList) != 0 || record.ECHDNSHostname != "" {
+		t.Fatalf("Register() ECH state = hash %q, config %d bytes, DNS hostname %q; want disabled", record.HostnameHash, len(record.ECHConfigList), record.ECHDNSHostname)
+	}
+	if lookedUp, ok := registry.Lookup("plain-sni.example.com"); !ok || lookedUp != record {
+		t.Fatalf("Lookup(plain SNI) = %v, %v, want registered lease", lookedUp, ok)
+	}
+}
+
 func TestLeaseRegistryAutomaticECHRouteFallsBackToPlainSNI(t *testing.T) {
 	t.Parallel()
 

--- a/sdk/api_client.go
+++ b/sdk/api_client.go
@@ -172,7 +172,7 @@ func (l *listener) registerLease(ctx context.Context, ttl time.Duration, udpEnab
 	if err != nil {
 		return types.RegisterResponse{}, nil, "", "", err
 	}
-	if streamLease {
+	if streamLease && l.echEnabled {
 		routeToken, err := identity.DeriveToken(l.identity, "ech-route", publicHostname, rootHostname)
 		if err != nil {
 			return types.RegisterResponse{}, nil, "", "", err
@@ -185,7 +185,7 @@ func (l *listener) registerLease(ctx context.Context, ttl time.Duration, udpEnab
 		}
 	}
 	var echConfigList []byte
-	if streamLease {
+	if streamLease && l.echEnabled {
 		_, echConfigList, err = l.tenantECHMaterials(publicHostname, routeHostname)
 		if err != nil {
 			return types.RegisterResponse{}, nil, "", "", err

--- a/sdk/expose.go
+++ b/sdk/expose.go
@@ -51,6 +51,7 @@ type ExposeConfig struct {
 	UDPAddr              string
 	UDPEnabled           bool
 	TCPEnabled           bool
+	ECH                  bool
 	MultiHop             []string
 	MultiHopDepth        int
 	BanMITM              bool
@@ -757,6 +758,7 @@ func (e *Exposure) reconcileRelayListeners(failOnError bool) error {
 			Identity:   cfg.Identity.Copy(),
 			UDPEnabled: cfg.UDPEnabled,
 			TCPEnabled: cfg.TCPEnabled,
+			ECH:        cfg.ECH,
 			BanMITM:    cfg.BanMITM,
 			Metadata: func() types.LeaseMetadata {
 				return e.Config().Metadata

--- a/sdk/listener.go
+++ b/sdk/listener.go
@@ -31,6 +31,7 @@ type listenerConfig struct {
 	Identity   types.Identity
 	UDPEnabled bool
 	TCPEnabled bool
+	ECH        bool
 	BanMITM    bool
 	Metadata   func() types.LeaseMetadata
 	RetryCount int
@@ -98,6 +99,7 @@ type listener struct {
 	relaySet       *discovery.RelaySet
 	udpEnabled     bool
 	tcpEnabled     bool
+	echEnabled     bool
 	dialTimeout    time.Duration
 	requestTimeout time.Duration
 	readyTarget    int
@@ -163,6 +165,7 @@ func newListener(ctx context.Context, route discovery.Route, cfg listenerConfig)
 		relaySet:       cfg.relaySet,
 		udpEnabled:     cfg.UDPEnabled,
 		tcpEnabled:     cfg.TCPEnabled,
+		echEnabled:     cfg.ECH,
 		dialTimeout:    defaultDialTimeout,
 		requestTimeout: defaultRequestTimeout,
 		readyTarget:    defaultReadyTarget,


### PR DESCRIPTION
```plantuml
@startuml
title Optional ECH stream tunnel lifecycle

start

partition "Client SDK" {
  :Read ExposeConfig.ECH;
  :Derive public hostname;

  if (Stream tunnel and ECH enabled?) then (yes)
    :Derive route hostname;
    :Derive tenant ECH keys and ECHConfigList;
    :Set RouteHostname, HostnameHash, and ECHConfigList;
  else (no)
    :Leave ECH registration fields empty;
    :Use public hostname as TLS ServerName;
  endif

  :Register lease;
}

partition "Relay lease registry" {
  :Validate hostname ownership and route fields;
  :Install lease routing state;

  if (ECHConfigList present?) then (yes)
    :Route by encrypted route hostname;
    :Keep public-hostname plaintext-SNI fallback;
    :Promote desired ECH DNS state;
  else (no)
    :Route directly by public hostname;
  endif
}

partition "ACME DNS manager" {
  if (ECH DNS promotion requested?) then (yes)
    :Lock echRecords map;
    :Find or create state keyed by public hostname;
    :Lock hostname state before releasing map lock;
    :Set present=true, dirty=true;
    :Reset staged delete progress;
    :Ensure A record;
    :Ensure HTTPS/ECH record;

    if (DNS operation succeeded?) then (yes)
      :Set dirty=false;
      :Reset retry failure count;
    else (no)
      :Increment retry failure count;
      :Schedule one retry worker for hostname;
    endif
    :Unlock hostname state;
  endif
}

partition "Lease removal" {
  :Confirm no active ECH lease requires the hostname;
  :Request ECH DNS deletion;
}

partition "ACME DNS manager" {
  :Lock map, then lock hostname state;
  :Set present=false, dirty=true;

  if (HTTPS record already deleted?) then (yes)
  else (no)
    :Delete HTTPS/ECH record;
    if (HTTPS delete succeeded?) then (yes)
      :Remember httpsDeleted=true;
    else (no)
      :Keep dirty state;
    endif
  endif

  if (HTTPS delete complete?) then (yes)
    :Delete A record;
  endif

  if (Delete completed?) then (yes)
    :Set dirty=false;
    :Reset retry failure count;
  else (no)
    :Increment retry failure count;
    :Schedule or wake hostname retry worker;
  endif
  :Unlock hostname state;
}

while (Hostname state is dirty?) is (yes)
  partition "Hostname retry worker" {
    :Wait jittered min(1s * 2^(n-1), 10m);
    :Wake early when desired state changes;
    :Lock only this hostname state;
    if (Desired state present?) then (yes)
      :Retry A then HTTPS/ECH create or update;
    else (no)
      :Resume delete from unfinished stage;
    endif
    :Update dirty flag and failure count;
    :Unlock hostname state;
  }
endwhile (no)

partition "State cleanup" {
  if (Absent, clean, and no retry scheduled?) then (yes)
    :Lock map, then hostname state;
    :Verify map still points to same state;
    :Delete hostname item from echRecords;
  endif
}

stop
@enduml
```

# Summary

## Optional ECH

- ECH is disabled by default.
- The SDK, CLI, and agent tunnel configuration now expose an `ECH` boolean.
- When ECH is disabled, the client does not derive ECH keys, a route hostname, a hostname hash, or an ECH config list.
- The public hostname remains the TLS ServerName and is routed through plaintext SNI.
- When ECH is enabled, the client derives tenant-specific ECH material while preserving plaintext-SNI fallback routing.

## Hostname-Owned DNS State

- Desired ECH DNS state is keyed by the public hostname.
- Each hostname has its own mutex, allowing DNS operations for different hostnames to proceed concurrently.
- Create, update, and delete operations for the same hostname are serialized so a stale delete cannot override a newer create.

## Change-Driven DNS Operations

- ECH DNS records are created, updated, or deleted only when lease state changes.
- The previous full reconciliation of every active ECH record every 10 minutes has been removed.
- Only failed or dirty hostname operations are retried.

## Safe Delete Recovery

- Delete progress records whether the HTTPS/ECH record has already been removed.
- If HTTPS deletion succeeds but A-record deletion fails, the retry resumes from the A-record step instead of repeating the HTTPS deletion.
- Completed, clean hostname state is removed from the in-memory state map.
- State removal revalidates both the state pointer and desired state, preventing concurrent replacement creates from being removed accidentally.

## Exponential Backoff

- Failed DNS operations use exponential backoff based on `1 second * 2^n`.
- Backoff is capped at 10 minutes and includes 50-100% jitter.
- A desired-state change wakes a sleeping retry worker so it can immediately reevaluate the hostname.

## Test Coverage

- ECH-disabled plaintext-SNI registration and routing.
- Failed DNS create, update, and delete retries.
- Resuming a partially completed delete.
- A stale delete racing with a replacement create.
- Removal of completed hostname state.
- Bounded exponential-backoff behavior.
- Concurrency verification with the Go race detector.
